### PR TITLE
Env: 커스텀 예외 처리 추가

### DIFF
--- a/src/main/java/ojosama/talkak/common/exception/ErrorResponse.java
+++ b/src/main/java/ojosama/talkak/common/exception/ErrorResponse.java
@@ -1,0 +1,13 @@
+package ojosama.talkak.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public record ErrorResponse(
+    String code,
+    String message,
+    String data
+) {
+    public static ErrorResponse of(HttpStatus status, String code, String message) {
+        return new ErrorResponse(code, message, status.value() + " " + status.getReasonPhrase());
+    }
+}

--- a/src/main/java/ojosama/talkak/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ojosama/talkak/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package ojosama.talkak.common.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(TalKakException.class)
+    public ResponseEntity<ErrorResponse> handleTalKakException(TalKakException e) {
+        return ResponseEntity.status(e.status())
+            .body(ErrorResponse.of(e.status(), e.code(), e.message()));
+    }
+}

--- a/src/main/java/ojosama/talkak/common/exception/TalKakException.java
+++ b/src/main/java/ojosama/talkak/common/exception/TalKakException.java
@@ -1,0 +1,30 @@
+package ojosama.talkak.common.exception;
+
+import ojosama.talkak.common.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class TalKakException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+
+    private TalKakException(ErrorCode errorCode) {
+        super(errorCode.message());
+        this.errorCode = errorCode;
+    }
+
+    public static TalKakException of(ErrorCode errorCode) {
+        return new TalKakException(errorCode);
+    }
+
+    public HttpStatus status() {
+        return errorCode.status();
+    }
+
+    public String code() {
+        return errorCode.code();
+    }
+
+    public String message() {
+        return errorCode.message();
+    }
+}

--- a/src/main/java/ojosama/talkak/common/exception/code/ErrorCode.java
+++ b/src/main/java/ojosama/talkak/common/exception/code/ErrorCode.java
@@ -1,0 +1,10 @@
+package ojosama.talkak.common.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    HttpStatus status();
+    String code();
+    String message();
+}

--- a/src/main/java/ojosama/talkak/common/exception/code/VideoError.java
+++ b/src/main/java/ojosama/talkak/common/exception/code/VideoError.java
@@ -1,0 +1,30 @@
+package ojosama.talkak.common.exception.code;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum VideoError implements ErrorCode {
+
+    /* 400 Bad Request */
+    VIDEO_NOT_FOUND(HttpStatus.BAD_REQUEST, "V001", "존재하지 않는 영상입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return status;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}


### PR DESCRIPTION
### 🛠️ 작업 내용

커스텀 에러 코드와 예외 처리에 관해 추가하였습니다.

---

### 💡 참고 사항

- 예시로 `VideoError`를 추가해 두었습니다. 도메인별로 필요한 에러코드 추가해서 사용하면 될 것 같습니다.
- 사용 예는 다음과 같습니다.
  ```java
  throw TalkakException.of(VideoError.VIDEO_NOT_FOUND);
  ```

---

### 🚨 현재 버그

---

### ☑️ Git Close

---