### PR TITLE
예외 및 request 로깅

### DIFF
--- a/src/main/java/ojosama/talkak/TalkakApplication.java
+++ b/src/main/java/ojosama/talkak/TalkakApplication.java
@@ -2,12 +2,13 @@ package ojosama.talkak;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
 @SpringBootApplication
+@EnableAspectJAutoProxy
 public class TalkakApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(TalkakApplication.class, args);
 	}
-
 }

--- a/src/main/java/ojosama/talkak/common/aop/LoggingAspect.java
+++ b/src/main/java/ojosama/talkak/common/aop/LoggingAspect.java
@@ -20,6 +20,14 @@ public class LoggingAspect {
     public void controllerPointCut() {
     }
 
+    @Pointcut("execution(* ojosama.talkak..service..*(..))")
+    public void servicePointCut() {
+    }
+
+    @Pointcut("execution(* ojosama.talkak..domain..*(..))")
+    public void domainPointCut() {
+    }
+
     @Around("controllerPointCut()")
     public Object logRequest(ProceedingJoinPoint joinPoint) throws Throwable {
         Object result = null;
@@ -36,7 +44,7 @@ public class LoggingAspect {
         return result;
     }
 
-    @AfterThrowing(pointcut = "execution(* ojosama.talkak..*(..))", throwing = "e")
+    @AfterThrowing(pointcut = "servicePointCut() || domainPointCut()", throwing = "e")
     public void logException(JoinPoint joinPoint, TalKakException e) {
         log.warn("Exception in {}.{}() with cause: {}", joinPoint.getSignature().getDeclaringTypeName(),
             joinPoint.getSignature().getName(), e.getMessage(), e);

--- a/src/main/java/ojosama/talkak/common/aop/LoggingAspect.java
+++ b/src/main/java/ojosama/talkak/common/aop/LoggingAspect.java
@@ -1,0 +1,20 @@
+package ojosama.talkak.common.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import ojosama.talkak.common.exception.TalKakException;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class LoggingAspect {
+
+    @AfterThrowing(pointcut = "execution(* ojosama.talkak..*(..))", throwing = "e")
+    public void logException(JoinPoint joinPoint, TalKakException e) {
+        log.warn("Exception in {}.{}() with cause: {}", joinPoint.getSignature().getDeclaringTypeName(),
+            joinPoint.getSignature().getName(), e.getMessage(), e);
+    }
+}

--- a/src/main/java/ojosama/talkak/common/aop/LoggingAspect.java
+++ b/src/main/java/ojosama/talkak/common/aop/LoggingAspect.java
@@ -32,13 +32,13 @@ public class LoggingAspect {
     public Object logRequest(ProceedingJoinPoint joinPoint) throws Throwable {
         Object result = null;
         long start = System.currentTimeMillis();
-        log.info("Enter: {}.{}() with argument[s] = {}", joinPoint.getSignature().getDeclaringTypeName(),
+        log.debug("Enter: {}.{}() with argument[s] = {}", joinPoint.getSignature().getDeclaringTypeName(),
             joinPoint.getSignature().getName(), Arrays.toString(joinPoint.getArgs()));
         try {
             result = joinPoint.proceed();
         } finally {
             long end = System.currentTimeMillis();
-            log.info("Exit : {}.{}() with result = {} ({}ms)", joinPoint.getSignature().getDeclaringTypeName(),
+            log.debug("Exit : {}.{}() with result = {} ({}ms)", joinPoint.getSignature().getDeclaringTypeName(),
                 joinPoint.getSignature().getName(), result, end - start);
         }
         return result;

--- a/src/main/java/ojosama/talkak/common/aop/LoggingAspect.java
+++ b/src/main/java/ojosama/talkak/common/aop/LoggingAspect.java
@@ -1,16 +1,40 @@
 package ojosama.talkak.common.aop;
 
+import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 import ojosama.talkak.common.exception.TalKakException;
 import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Aspect
 @Component
 public class LoggingAspect {
+
+    @Pointcut("execution(* ojosama.talkak..controller..*(..))")
+    public void controllerPointCut() {
+    }
+
+    @Around("controllerPointCut()")
+    public Object logRequest(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object result = null;
+        long start = System.currentTimeMillis();
+        log.info("Enter: {}.{}() with argument[s] = {}", joinPoint.getSignature().getDeclaringTypeName(),
+            joinPoint.getSignature().getName(), Arrays.toString(joinPoint.getArgs()));
+        try {
+            result = joinPoint.proceed();
+        } finally {
+            long end = System.currentTimeMillis();
+            log.info("Exit : {}.{}() with result = {} ({}ms)", joinPoint.getSignature().getDeclaringTypeName(),
+                joinPoint.getSignature().getName(), result, end - start);
+        }
+        return result;
+    }
 
     @AfterThrowing(pointcut = "execution(* ojosama.talkak..*(..))", throwing = "e")
     public void logException(JoinPoint joinPoint, TalKakException e) {


### PR DESCRIPTION
### 🛠️ 작업 내용

Spring AOP를 이용해 예외 발생 시 로그를 출력하도록 했습니다.
하는 김에 컨트롤러 진입 및 진출 시 request, response, 실행 시간 등에 대한 로그 출력도 추가하였습니다.

---

### 💡 참고 사항

- ~~컨트롤러 로그를 우선 `INFO` 레벨로 찍었는데 `DEBUG` 레벨로 찍는 게 좋을지 의견 주시면 감사하겠습니다.~~
  - 컨트롤러 로그는 `DEBUG` 레벨로 찍습니다. 로그 레벨을 설정해주시면 확인할 수 있습니다. 아래는 `ojosama.talkak` 패키지 전체에 대해 설정한 예시입니다.
  
    .yaml
    ```yaml
    logging:
      level:
        ojosama:
          talkak: debug
    ```
    .properties
    ```properties
    logging.level.ojosama.talkak=debug
    ```
- 커밋 메시지 태그 선택을 잘못했네요..

---

### 🚨 현재 버그

임의의 컨트롤러를 만들어서 테스트했기 때문에 다른 버그가 있을 수 있습니다.

---

### ☑️ Git Close

---