### PR TITLE
댓글 / 좋아요 기능 Serivce 및 Controller 구현

### DIFF
--- a/src/main/java/ojosama/talkak/comment/controller/CommentController.java
+++ b/src/main/java/ojosama/talkak/comment/controller/CommentController.java
@@ -27,7 +27,7 @@ public class CommentController {
 
     @PostMapping
     public ResponseEntity<CommentResponse> createComment(
-        @PathVariable("video_id") Long videoId,
+        @PathVariable("videoId") Long videoId,
         @RequestHeader("memberId") Long memberId,
         @RequestBody CommentRequest commentRequest) {
         return ResponseEntity.ok(commentService.createComment(videoId, memberId, commentRequest));
@@ -39,16 +39,16 @@ public class CommentController {
         return ResponseEntity.ok().body(comments);
     }
 
-    @PutMapping("/{comment_id}")
+    @PutMapping("/{commentId}")
     public ResponseEntity<String> updateComment(
-        @PathVariable("comment_id") Long commentId,
+        @PathVariable("commentId") Long commentId,
         @RequestHeader("memberId") Long memberId,
         @RequestBody CommentRequest commentRequest) {
         commentService.updateComment(commentId, memberId, commentRequest);
         return ResponseEntity.ok("Comment updated successfully");
     }
 
-    @DeleteMapping("/{comment_id}")
+    @DeleteMapping("/{commentId}")
     public ResponseEntity<String> deleteComment(
         @PathVariable("comment_id") Long commentId,
         @RequestHeader("memberId") Long memberId) {

--- a/src/main/java/ojosama/talkak/comment/controller/CommentController.java
+++ b/src/main/java/ojosama/talkak/comment/controller/CommentController.java
@@ -1,11 +1,17 @@
 package ojosama.talkak.comment.controller;
 
 import java.util.List;
+import ojosama.talkak.comment.dto.CommentRequest;
 import ojosama.talkak.comment.dto.CommentResponse;
 import ojosama.talkak.comment.service.CommentService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,10 +25,34 @@ public class CommentController {
         this.commentService = commentService;
     }
 
+    @PostMapping
+    public ResponseEntity<CommentResponse> createComment(
+        @PathVariable("video_id") Long videoId,
+        @RequestHeader("memberId") Long memberId,
+        @RequestBody CommentRequest commentRequest) {
+        return ResponseEntity.ok(commentService.createComment(videoId, memberId, commentRequest));
+    }
+
     @GetMapping
     public ResponseEntity<?> getCommentsByVideoId(@PathVariable Long videoId) {
         List<CommentResponse> comments = commentService.getCommentsByVideoId(videoId);
         return ResponseEntity.ok().body(comments);
     }
 
+    @PutMapping("/{comment_id}")
+    public ResponseEntity<String> updateComment(
+        @PathVariable("comment_id") Long commentId,
+        @RequestHeader("memberId") Long memberId,
+        @RequestBody CommentRequest commentRequest) {
+        commentService.updateComment(commentId, memberId, commentRequest);
+        return ResponseEntity.ok("Comment updated successfully");
+    }
+
+    @DeleteMapping("/{comment_id}")
+    public ResponseEntity<String> deleteComment(
+        @PathVariable("comment_id") Long commentId,
+        @RequestHeader("memberId") Long memberId) {
+        commentService.deleteComment(commentId, memberId);
+        return ResponseEntity.ok("Comment deleted successfully");
+    }
 }

--- a/src/main/java/ojosama/talkak/comment/model/Comment.java
+++ b/src/main/java/ojosama/talkak/comment/model/Comment.java
@@ -33,6 +33,14 @@ public class Comment {
         this.video = video;
         this.content = content;
     }
+
+    public Comment(Long id, Member member, Video video, String content) {
+        this.id = id;
+        this.member = member;
+        this.video = video;
+        this.content = content;
+    }
+
     public Long getId() {
         return id;
     }
@@ -49,9 +57,6 @@ public class Comment {
     }
     public void updateContent(String newContent) {
         this.content = newContent;
-    }
-    public void setId(Long id) {
-        this.id = id;
     }
 
 }

--- a/src/main/java/ojosama/talkak/comment/model/Comment.java
+++ b/src/main/java/ojosama/talkak/comment/model/Comment.java
@@ -28,19 +28,12 @@ public class Comment {
     public Comment() {
     }
 
-    public void setContent(String content) {
+    public Comment(Member member, Video video, String content) {
+        this.member = member;
+        this.video = video;
         this.content = content;
     }
-
-    public void setMember(Member member) {
-        this.member = member;
-    }
-
-    public void setVideo(Video video) {
-        this.video = video;
-    }
-
-    public long getId() {
+    public Long getId() {
         return id;
     }
 
@@ -51,4 +44,14 @@ public class Comment {
     public Member getMember() {
         return member;
     }
+    public Video getVideo() {
+        return video;
+    }
+    public void updateContent(String newContent) {
+        this.content = newContent;
+    }
+    public void setId(long id) {
+        this.id = id;
+    }
+
 }

--- a/src/main/java/ojosama/talkak/comment/model/Comment.java
+++ b/src/main/java/ojosama/talkak/comment/model/Comment.java
@@ -50,7 +50,7 @@ public class Comment {
     public void updateContent(String newContent) {
         this.content = newContent;
     }
-    public void setId(long id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/ojosama/talkak/comment/repository/CommentRepository.java
+++ b/src/main/java/ojosama/talkak/comment/repository/CommentRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByVideoId(long videoId);
+    Comment findByMemberIdAndVideoId(long memberId, long videoId);
 }

--- a/src/main/java/ojosama/talkak/comment/repository/CommentRepository.java
+++ b/src/main/java/ojosama/talkak/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package ojosama.talkak.comment.repository;
 
 import java.util.List;
+import java.util.Optional;
 import ojosama.talkak.comment.model.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,5 +9,4 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByVideoId(long videoId);
-    Comment findByMemberIdAndVideoId(long memberId, long videoId);
 }

--- a/src/main/java/ojosama/talkak/common/exception/code/CommentError.java
+++ b/src/main/java/ojosama/talkak/common/exception/code/CommentError.java
@@ -1,0 +1,31 @@
+package ojosama.talkak.common.exception.code;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum CommentError implements ErrorCode {
+    UNAUTHORIZED_USER(HttpStatus.BAD_REQUEST, "C001", "인증되지 않은 유저입니다."),
+    INVALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "C002", "유효하지 않은 memberId 입니다."),
+    INVALID_VIDEO_ID(HttpStatus.BAD_REQUEST, "C003", "유효하지 않은 videoID 입니다."),
+    INVALID_COMMENT_ID(HttpStatus.BAD_REQUEST, "C004", "유효하지 않은 commentId 입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return status;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/ojosama/talkak/common/exception/code/ReactionError.java
+++ b/src/main/java/ojosama/talkak/common/exception/code/ReactionError.java
@@ -1,0 +1,30 @@
+package ojosama.talkak.common.exception.code;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ReactionError implements ErrorCode {
+    UNAUTHORIZED_USER(HttpStatus.BAD_REQUEST, "R001", "인증되지 않은 유저입니다."),
+    INVALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "R002", "유효하지 않은 memberId 입니다."),
+    INVALID_VIDEO_ID(HttpStatus.BAD_REQUEST, "R003", "유효하지 않은 videoID 입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return status;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/ojosama/talkak/member/model/Member.java
+++ b/src/main/java/ojosama/talkak/member/model/Member.java
@@ -2,6 +2,8 @@ package ojosama.talkak.member.model;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -21,9 +23,10 @@ public class Member {
     private String imageUrl;
     private String email;
     private boolean gender;
-    private int age;
-    private int membership;
-    private int point;
+    private Integer age;
+    @Enumerated(EnumType.STRING)
+    private MembershipTier membership;
+    private Integer point;
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Comment> comments;
 
@@ -32,7 +35,7 @@ public class Member {
         this.username = username;
     }
 
-    public long getId() {
+    public Long getId() {
         return id;
     }
 

--- a/src/main/java/ojosama/talkak/member/model/Member.java
+++ b/src/main/java/ojosama/talkak/member/model/Member.java
@@ -22,7 +22,7 @@ public class Member {
     private String username;
     private String imageUrl;
     private String email;
-    private boolean gender;
+    private Boolean gender;
     private Integer age;
     @Enumerated(EnumType.STRING)
     private MembershipTier membership;

--- a/src/main/java/ojosama/talkak/member/model/Member.java
+++ b/src/main/java/ojosama/talkak/member/model/Member.java
@@ -27,6 +27,11 @@ public class Member {
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Comment> comments;
 
+    public Member(Long id, String username) {
+        this.id = id;
+        this.username = username;
+    }
+
     public long getId() {
         return id;
     }

--- a/src/main/java/ojosama/talkak/member/model/MembershipTier.java
+++ b/src/main/java/ojosama/talkak/member/model/MembershipTier.java
@@ -1,0 +1,23 @@
+package ojosama.talkak.member.model;
+
+public enum MembershipTier {
+    Basic, Standard, Premium;
+
+    public static MembershipTier fromInt(int tier) {
+        return switch (tier) {
+            case 0 -> Basic;
+            case 1 -> Standard;
+            case 2 -> Premium;
+            default -> throw new IllegalArgumentException("Invalid tier: " + tier);
+        };
+    }
+
+    public int toInt() {
+        return switch (this) {
+            case Basic -> 0;
+            case Standard -> 1;
+            case Premium -> 2;
+            default -> throw new IllegalArgumentException("Invalid tier");
+        };
+    }
+}

--- a/src/main/java/ojosama/talkak/reaction/controller/ReactionController.java
+++ b/src/main/java/ojosama/talkak/reaction/controller/ReactionController.java
@@ -1,0 +1,28 @@
+package ojosama.talkak.reaction.controller;
+
+import ojosama.talkak.reaction.service.ReactionService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/videos/{videoId}/reactions")
+public class ReactionController {
+
+    private final ReactionService reactionService;
+
+    public ReactionController(ReactionService reactionService) {
+        this.reactionService = reactionService;
+    }
+
+    @PostMapping("/like")
+    public ResponseEntity<Void> toggleLike(
+        @PathVariable Long videoId,
+        @RequestHeader("memberId") Long memberId) {
+        reactionService.toggleLike(videoId, memberId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/ojosama/talkak/reaction/model/Reaction.java
+++ b/src/main/java/ojosama/talkak/reaction/model/Reaction.java
@@ -26,36 +26,27 @@ public class Reaction {
     @JoinColumn(name = "video_id", insertable = false, updatable = false)
     private Video video;
 
+    public Reaction(ReactionId reactionId, Member member, Video video, boolean reactionType) {
+        this.id = reactionId;
+        this.member = member;
+        this.video = video;
+        this.reaction = reactionType;
+    }
+
     // Getters and setters
     public ReactionId getId() {
         return id;
-    }
-
-    public void setId(ReactionId id) {
-        this.id = id;
     }
 
     public boolean isReaction() {
         return reaction;
     }
 
-    public void setReaction(boolean reaction) {
-        this.reaction = reaction;
-    }
-
     public Member getMember() {
         return member;
     }
 
-    public void setMember(Member member) {
-        this.member = member;
-    }
-
     public Video getVideo() {
         return video;
-    }
-
-    public void setVideo(Video video) {
-        this.video = video;
     }
 }

--- a/src/main/java/ojosama/talkak/reaction/model/Reaction.java
+++ b/src/main/java/ojosama/talkak/reaction/model/Reaction.java
@@ -16,7 +16,7 @@ public class Reaction {
     @EmbeddedId
     private ReactionId id;  // 복합 키를 포함하는 필드
 
-    private boolean reaction;
+    private Boolean reaction;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_id", insertable = false, updatable = false)
@@ -38,7 +38,7 @@ public class Reaction {
         return id;
     }
 
-    public boolean isReaction() {
+    public Boolean isReaction() {
         return reaction;
     }
 

--- a/src/main/java/ojosama/talkak/video/model/Video.java
+++ b/src/main/java/ojosama/talkak/video/model/Video.java
@@ -28,14 +28,14 @@ public class Video {
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
-    private long categoryId;
+    private Long categoryId;
     private String thumbnail;
     private boolean isPublic;
-    private long countLikes;
+    private Long countLikes;
     @OneToMany(mappedBy = "video", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Comment> comments;
 
-    public Video(Long id, String title, int countLikes) {
+    public Video(Long id, String title, Long countLikes) {
         this.id = id;
         this.title = title;
         this.countLikes = countLikes;

--- a/src/main/java/ojosama/talkak/video/model/Video.java
+++ b/src/main/java/ojosama/talkak/video/model/Video.java
@@ -31,6 +31,26 @@ public class Video {
     private long categoryId;
     private String thumbnail;
     private boolean isPublic;
+    private long countLikes;
     @OneToMany(mappedBy = "video", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Comment> comments;
+
+    public Video(Long id, String title, int countLikes) {
+        this.id = id;
+        this.title = title;
+        this.countLikes = countLikes;
+
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void incrementLikes() {
+        this.countLikes++;
+    }
+
+    public void decrementLikes() {
+        this.countLikes--;
+    }
 }

--- a/src/main/java/ojosama/talkak/video/model/Video.java
+++ b/src/main/java/ojosama/talkak/video/model/Video.java
@@ -30,7 +30,7 @@ public class Video {
 
     private Long categoryId;
     private String thumbnail;
-    private boolean isPublic;
+    private Boolean isPublic;
     private Long countLikes;
     @OneToMany(mappedBy = "video", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Comment> comments;

--- a/src/test/java/ojosama/talkak/comment/service/CommentServiceTest.java
+++ b/src/test/java/ojosama/talkak/comment/service/CommentServiceTest.java
@@ -47,8 +47,7 @@ public class CommentServiceTest {
         MockitoAnnotations.openMocks(this);
         member = new Member(1L, "username");
         video = new Video(1L, "video title", 0L);
-        comment = new Comment(member, video, "This is a comment.");
-        comment.setId(1L);
+        comment = new Comment(1L, member, video, "This is a comment.");
     }
 
     @Test

--- a/src/test/java/ojosama/talkak/comment/service/CommentServiceTest.java
+++ b/src/test/java/ojosama/talkak/comment/service/CommentServiceTest.java
@@ -46,7 +46,7 @@ public class CommentServiceTest {
     public void setup() {
         MockitoAnnotations.openMocks(this);
         member = new Member(1L, "username");
-        video = new Video(1L, "video title", 0);
+        video = new Video(1L, "video title", 0L);
         comment = new Comment(member, video, "This is a comment.");
         comment.setId(1L);
     }

--- a/src/test/java/ojosama/talkak/comment/service/CommentServiceTest.java
+++ b/src/test/java/ojosama/talkak/comment/service/CommentServiceTest.java
@@ -1,0 +1,225 @@
+package ojosama.talkak.comment.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import ojosama.talkak.comment.dto.CommentRequest;
+import ojosama.talkak.comment.dto.CommentResponse;
+import ojosama.talkak.comment.model.Comment;
+import ojosama.talkak.comment.repository.CommentRepository;
+import ojosama.talkak.common.exception.TalKakException;
+import ojosama.talkak.member.model.Member;
+import ojosama.talkak.member.repository.MemberRepository;
+import ojosama.talkak.video.model.Video;
+import ojosama.talkak.video.repository.VideoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class CommentServiceTest {
+
+    @InjectMocks
+    private CommentService commentService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private VideoRepository videoRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    private Member member;
+    private Video video;
+    private Comment comment;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        member = new Member(1L, "username");
+        video = new Video(1L, "video title", 0);
+        comment = new Comment(member, video, "This is a comment.");
+        comment.setId(1L);
+    }
+
+    @Test
+    public void testCreateComment() {
+        // Given
+        Long memberId = 1L;
+        Long videoId = 1L;
+        CommentRequest commentRequest = new CommentRequest("This is a comment.");
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(videoRepository.findById(videoId)).thenReturn(Optional.of(video));
+        when(commentRepository.save(any(Comment.class))).thenReturn(comment);
+
+        // When
+        CommentResponse response = commentService.createComment(memberId, videoId, commentRequest);
+
+        // Then
+        assertEquals(commentRequest.content(), response.content());
+        assertEquals(member.getId(), response.member().memberId());
+        verify(commentRepository).save(any(Comment.class));
+    }
+
+    @Test
+    public void testCreateComment_InvalidMember() {
+        // Given
+        Long memberId = 1L;
+        Long videoId = 1L;
+        CommentRequest commentRequest = new CommentRequest("This is a comment.");
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+        when(videoRepository.findById(videoId)).thenReturn(Optional.of(video));
+
+        // When & Then
+        TalKakException exception = assertThrows(TalKakException.class, () -> {
+            commentService.createComment(memberId, videoId, commentRequest);
+        });
+        assertEquals("C002", exception.code());
+    }
+
+    @Test
+    public void testCreateComment_InvalidVideo() {
+        // Given
+        Long memberId = 1L;
+        Long videoId = 1L;
+        CommentRequest commentRequest = new CommentRequest("This is a comment.");
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(videoRepository.findById(videoId)).thenReturn(Optional.empty());
+
+        // When & Then
+        TalKakException exception = assertThrows(TalKakException.class, () -> {
+            commentService.createComment(memberId, videoId, commentRequest);
+        });
+        assertEquals("C003", exception.code());
+    }
+
+    @Test
+    public void testGetCommentsByVideoId() {
+        // Given
+        Long videoId = 1L;
+
+        when(commentRepository.findByVideoId(videoId)).thenReturn(Collections.singletonList(comment));
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+
+        // When
+        List<CommentResponse> responses = commentService.getCommentsByVideoId(videoId);
+
+        // Then
+        assertEquals(1, responses.size());
+        assertEquals(comment.getContent(), responses.get(0).content());
+        assertEquals(member.getId(), responses.get(0).member().memberId());
+    }
+
+    @Test
+    public void testUpdateComment() {
+        // Given
+        Long commentId = 1L;
+        Long memberId = 1L;
+        CommentRequest commentRequest = new CommentRequest("Updated comment content.");
+
+        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        when(commentRepository.save(comment)).thenReturn(comment);
+
+        // When
+        CommentResponse response = commentService.updateComment(commentId, memberId, commentRequest);
+
+        // Then
+        assertEquals(commentRequest.content(), response.content());
+        verify(commentRepository).save(comment);
+    }
+
+    @Test
+    public void testUpdateComment_InvalidComment() {
+        // Given
+        Long commentId = 1L;
+        Long memberId = 1L;
+        CommentRequest commentRequest = new CommentRequest("Updated comment content.");
+
+        when(commentRepository.findById(commentId)).thenReturn(Optional.empty());
+
+        // When & Then
+        TalKakException exception = assertThrows(TalKakException.class, () -> {
+            commentService.updateComment(commentId, memberId, commentRequest);
+        });
+        assertEquals("C004", exception.code());
+    }
+
+    @Test
+    public void testUpdateComment_UnauthorizedUser() {
+        // Given
+        Long commentId = 1L;
+        Long memberId = 2L;
+        CommentRequest commentRequest = new CommentRequest("Updated comment content.");
+
+        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(memberRepository.findById(memberId)).thenReturn(
+            Optional.of(new Member(2L, "anotherUser")));
+
+        // When & Then
+        TalKakException exception = assertThrows(TalKakException.class, () -> {
+            commentService.updateComment(commentId, memberId, commentRequest);
+        });
+        assertEquals("C001", exception.code());
+    }
+
+    @Test
+    public void testDeleteComment() {
+        // Given
+        Long commentId = 1L;
+        Long memberId = 1L;
+
+        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        // When
+        commentService.deleteComment(commentId, memberId);
+
+        // Then
+        verify(commentRepository).delete(comment);
+    }
+
+    @Test
+    public void testDeleteComment_InvalidComment() {
+        // Given
+        Long commentId = 1L;
+        Long memberId = 1L;
+
+        when(commentRepository.findById(commentId)).thenReturn(Optional.empty());
+
+        // When & Then
+        TalKakException exception = assertThrows(TalKakException.class, () -> {
+            commentService.deleteComment(commentId, memberId);
+        });
+        assertEquals("C004", exception.code());
+    }
+
+    @Test
+    public void testDeleteComment_UnauthorizedUser() {
+        // Given
+        Long commentId = 1L;
+        Long memberId = 2L; // Different member
+
+        when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+        when(memberRepository.findById(memberId)).thenReturn(
+            Optional.of(new Member(2L, "anotherUser")));
+
+        // When & Then
+        TalKakException exception = assertThrows(TalKakException.class, () -> {
+            commentService.deleteComment(commentId, memberId);
+        });
+        assertEquals("C001", exception.code());
+    }
+}


### PR DESCRIPTION
### 🛠️ 작업 내용

#### `Comment`
- Service Layer, Controller Layer 완성
- Service layer의 테스트 코드 `CommentServiceTest` 작성
#### `Reaction`
- 좋아요 기능을 구현 완료
---

### 💡 참고 사항
#### `Reaction`
실 사용자는 좋아요 버튼이나 싫어요 버튼을 누르는 것으로 영상에 대한 반응을 남깁니다. 즉, 내가 기존에 '좋아요' 라고 반응을 남겼는데 다시 '싫어요' 버튼을 누르는 경우에 '좋아요' 를 취소하고 '싫어요' 로 바꿔야합니다. 이때 `Video` 엔티티에는 `countLikes` 라는 변수로 좋아요의 갯수만 카운트합니다. 그럼 2가지 경우로 크게 나누어집니다.
1. 좋아요 버튼을 누른 경우
  a) 이미 반응을 남긴 경우 -> 이전에 남겼던 반응이 좋아요 인지 싫어요 인지 구분
  b) 처음 반응을 남기는 경우
2. 싫어요 버튼을 누른 경우
  a) 이미 반응을 남긴 경우 -> 이전에 남겼던 반응이 좋아요 인지 싫어요 인지 구분
  b) 처음 반응을 남기는 경우 
---
이렇게 싫어요 기능도 같이 구현을 하려고 하면 복잡해지고 어차피 `Video` 엔티티에 싫어요 수를 세는 변수는 없기 때문에 싫어요 기능의 필요성도 의문이 들어 우선적으로 좋아요 기능만 구현했습니다.

### 🚨 현재 버그
---

### ☑️ Git Close

---