### PR TITLE
Age/Category enum 타입으로 변경

### DIFF
--- a/src/main/java/ojosama/talkak/category/model/Category.java
+++ b/src/main/java/ojosama/talkak/category/model/Category.java
@@ -1,6 +1,8 @@
 package ojosama.talkak.category.model;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,6 +22,7 @@ public class Category {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String name;
+    @Enumerated(EnumType.STRING)
+    private CategoryType categoryType;
 
 }

--- a/src/main/java/ojosama/talkak/category/model/CategoryType.java
+++ b/src/main/java/ojosama/talkak/category/model/CategoryType.java
@@ -1,0 +1,24 @@
+package ojosama.talkak.category.model;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum CategoryType {
+    MUSIC("음악"), JOURNEY("여행"), GAME("게임"), SPORT("스포츠"), FOOD("음식");
+
+    private final String name;
+
+    public static CategoryType fromName(String name) {
+        return Arrays.stream(CategoryType.values())
+            .filter(categoryType -> categoryType.getName().equals(name))
+            .findFirst()
+            .orElse(null);
+    }
+
+}

--- a/src/main/java/ojosama/talkak/category/model/MemberCategory.java
+++ b/src/main/java/ojosama/talkak/category/model/MemberCategory.java
@@ -42,7 +42,7 @@ public class MemberCategory {
         this.category = category;
     }
 
-    public static void isValidCategories(List<String> categories) {
+    public static void isValidCategories(List<Long> categories) {
         if(categories.size() != 3) {
             throw TalKakException.of(MemberError.ERROR_UPDATE_MEMBER_INFO);
         }

--- a/src/main/java/ojosama/talkak/category/repository/CategoryRepository.java
+++ b/src/main/java/ojosama/talkak/category/repository/CategoryRepository.java
@@ -1,11 +1,14 @@
 package ojosama.talkak.category.repository;
 import java.util.Optional;
 import ojosama.talkak.category.model.Category;
+import ojosama.talkak.category.model.CategoryType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-    Optional<Category> findByName(String name);
+    Optional<Category> findByCategoryType(CategoryType categoryType);
     String findCategoryById(Long categoryId);
 
 }

--- a/src/main/java/ojosama/talkak/member/dto/MyPageInfoRequest.java
+++ b/src/main/java/ojosama/talkak/member/dto/MyPageInfoRequest.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 public record MyPageInfoRequest(
     String gender,
-    Integer age,
-    List<String> categories
+    String age,
+    List<Long> categories
 ) {
 
 

--- a/src/main/java/ojosama/talkak/member/dto/MyPageInfoResponse.java
+++ b/src/main/java/ojosama/talkak/member/dto/MyPageInfoResponse.java
@@ -6,17 +6,23 @@ import ojosama.talkak.member.model.Member;
 
 public record MyPageInfoResponse(
     String gender,
-    Integer age,
-    List<String> categories
+    String age,
+    List<CategoryResponse> categories
 ) {
+    public record CategoryResponse(
+        Long id,
+        String name
+    ) {
+    }
+
 
     public static MyPageInfoResponse of(Member member, List<Category> categories) {
         String gender = !member.getGender() ? "남자" : "여자";
-        Integer age = member.getAge();
-        List<String> names = categories.stream()
-            .map(Category::getName)
+        String age = member.getAge().getName();
+        List<CategoryResponse> categoryResponses = categories.stream()
+            .map(c -> new CategoryResponse(c.getId(), c.getCategoryType().getName()))
             .toList();
-        return new MyPageInfoResponse(gender, age, names);
+        return new MyPageInfoResponse(gender, age, categoryResponses);
     }
-
 }
+

--- a/src/main/java/ojosama/talkak/member/model/Age.java
+++ b/src/main/java/ojosama/talkak/member/model/Age.java
@@ -1,2 +1,20 @@
-package ojosama.talkak.member.model;public enum Age {
+package ojosama.talkak.member.model;
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import ojosama.talkak.category.model.CategoryType;
+
+@RequiredArgsConstructor
+@Getter
+public enum Age {
+    TEN("10대"), TWENTY("20대"), THIRTY("30대"), FORTY("40대"), FIFTY("50대 이상");
+
+    private final String name;
+
+    public static Age fromName(String name) {
+        return Arrays.stream(Age.values())
+            .filter(age -> age.getName().equals(name))
+            .findFirst()
+            .orElse(null);
+    }
 }

--- a/src/main/java/ojosama/talkak/member/model/Member.java
+++ b/src/main/java/ojosama/talkak/member/model/Member.java
@@ -34,7 +34,8 @@ public class Member {
     private String imageUrl;
     private String email;
     private Boolean gender;
-    private Integer age;
+    @Enumerated(EnumType.STRING)
+    private Age age;
     @Enumerated(EnumType.STRING)
     private MembershipTier membership;
     private Integer point;
@@ -46,12 +47,13 @@ public class Member {
         this.username = username;
     }
   
-    public void updateMemberInfo(String gender, Integer age) {
-        if (!gender.matches("남자|여자") || age == null || age < 10 || age > 100) {
+    public void updateMemberInfo(String gender, String age) {
+        Age newAge = Age.fromName(age);
+        if (!gender.matches("남자|여자") || newAge == null) {
             throw TalKakException.of(MemberError.ERROR_UPDATE_MEMBER_INFO);
         }
       
         this.gender = !gender.equals("남자");
-        this.age = age;
+        this.age = newAge;
     }
 }

--- a/src/main/java/ojosama/talkak/member/service/MyPageService.java
+++ b/src/main/java/ojosama/talkak/member/service/MyPageService.java
@@ -48,7 +48,7 @@ public class MyPageService {
             memberId);
         memberCategories.removeIf(
             mc -> request.categories().stream().noneMatch(
-                c -> c.equals(mc.getCategory().getName())
+                c -> c.equals(mc.getCategory().getId())
             )
         );
 
@@ -56,10 +56,10 @@ public class MyPageService {
         List<MemberCategory> newMemberCategories = request.categories().stream()
             .filter(
                 c -> memberCategories.stream().noneMatch(
-                    mc -> mc.getCategory().getName().equals(c)
+                    mc -> mc.getCategory().getId().equals(c)
                 )
             ).map(c -> {
-                Category category = categoryRepository.findByName(c)
+                Category category = categoryRepository.findById(c)
                     .orElseThrow(() -> TalKakException.of(CategoryError.NOT_EXISTING_CATEGORY));
                 return memberCategoryRepository.save(new MemberCategory(member, category));
             })


### PR DESCRIPTION
### 🛠️ 작업 내용
- Member의 멤버 변수인 Age를 enum 타입으로 변경하였습니다.
- Category의 멤버 변수인 name을 enum 타입으로 변경하였습니다.
---

### 💡 참고 사항
- Category의 경우 static 변수로 관리하는 방식이랑 기존처럼 db에 저장하기 중 후자 방식을 택하였습니다. (Category 자체가 독립적으로 존재해야하고 다른 Entity와 연관관계를 맺기 때문에 Entity로 db에 관리하는 것이 낫다고 판단하였습니다.)
- 마이페이지 조회/수정 API도 아래와 같이 받도록 변경해보았습니다.

- 수정 Request
```
{
  "gender": "string",
	"age": "number",
	"categories": ["number", "number"]
}
```
- 공통 Response
```
{
  "gender": "string",
  "age": "number",
  "categories": [
      {
	"id" : "number",
	"name" : "string"
      },
      {
	"id" : "number",
	"name" : "string"
      },
  ]
}
```
---

### 🚨 현재 버그

---

### ☑️ Git Close
- close #34 
---