### PR TITLE
Upload and download

### DIFF
--- a/src/main/java/ojosama/talkak/video/controller/VideoController.java
+++ b/src/main/java/ojosama/talkak/video/controller/VideoController.java
@@ -1,11 +1,16 @@
 package ojosama.talkak.video.controller;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
+import ojosama.talkak.video.dto.VideoRequest;
+import ojosama.talkak.video.dto.VideoResponse;
 import ojosama.talkak.video.dto.YoutubeApiResponse;
 import ojosama.talkak.video.dto.YoutubeCategoryRequest;
 import ojosama.talkak.video.dto.YoutubeUrlValidationRequest;
 import ojosama.talkak.video.dto.YoutubeUrlValidationResponse;
+import ojosama.talkak.video.service.AwsS3Service;
 import ojosama.talkak.video.service.VideoService;
 import ojosama.talkak.video.service.YoutubeService;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +19,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/videos")
@@ -22,14 +29,32 @@ public class VideoController {
 
     private final VideoService videoService;
     private final YoutubeService youtubeService;
+    private final AwsS3Service awsS3Service;
 
-    public VideoController(VideoService videoService, YoutubeService youtubeService) {
+    public VideoController(VideoService videoService, YoutubeService youtubeService,
+        AwsS3Service awsS3Service) {
         this.videoService = videoService;
         this.youtubeService = youtubeService;
+        this.awsS3Service = awsS3Service;
+    }
+
+    @PostMapping("/upload")
+    public ResponseEntity<VideoResponse> uploadShortsVideo(
+        @RequestParam("file") MultipartFile file, VideoRequest videoRequest) throws IOException {
+        VideoResponse response = awsS3Service.uploadVideo(file, videoRequest);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{videoId}/extract")
+    public ResponseEntity<URL> downloadVideo(@PathVariable Long videoId)
+        throws MalformedURLException {
+        URL downloadUrl = awsS3Service.generateDownloadUrl(videoId);
+        return ResponseEntity.ok(downloadUrl);
     }
 
     @PostMapping("/youtube-url-validation")
-    public ResponseEntity<YoutubeUrlValidationResponse> validateYoutubeUrl(@RequestBody YoutubeUrlValidationRequest req) {
+    public ResponseEntity<YoutubeUrlValidationResponse> validateYoutubeUrl(
+        @RequestBody YoutubeUrlValidationRequest req) {
         YoutubeUrlValidationResponse response = videoService.validateYoutubeUrl(req);
         return ResponseEntity.ok(response);
     }
@@ -43,9 +68,11 @@ public class VideoController {
 
     // 메인페이지에서 유튜브 관련 영상 불러오기(카테고리 지정)
     @GetMapping("/youtube/{categoryId}")
-    public ResponseEntity<List<YoutubeApiResponse>> getPopularYoutubeShortsByCategory(@PathVariable("categoryId")
-    YoutubeCategoryRequest youtubeCategoryRequest) throws IOException {
-        List<YoutubeApiResponse> response =  youtubeService.getShortsByCategory(youtubeCategoryRequest);
+    public ResponseEntity<List<YoutubeApiResponse>> getPopularYoutubeShortsByCategory(
+        @PathVariable("categoryId")
+        YoutubeCategoryRequest youtubeCategoryRequest) throws IOException {
+        List<YoutubeApiResponse> response = youtubeService.getShortsByCategory(
+            youtubeCategoryRequest);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/ojosama/talkak/video/dto/VideoRequest.java
+++ b/src/main/java/ojosama/talkak/video/dto/VideoRequest.java
@@ -1,0 +1,5 @@
+package ojosama.talkak.video.dto;
+
+public record VideoRequest(String title, Long memberId, Long categoryId) {
+
+}

--- a/src/main/java/ojosama/talkak/video/dto/VideoResponse.java
+++ b/src/main/java/ojosama/talkak/video/dto/VideoResponse.java
@@ -1,0 +1,5 @@
+package ojosama.talkak.video.dto;
+
+public record VideoResponse(Long id, String title, Long memberId, Long categoryId, String uniqueFileName) {
+
+}

--- a/src/main/java/ojosama/talkak/video/model/Video.java
+++ b/src/main/java/ojosama/talkak/video/model/Video.java
@@ -23,7 +23,7 @@ public class Video {
     private Long id;
     private Long memberId;
     private String title;
-    private String videoUrl;
+    private String uniqueFileName;
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -42,8 +42,27 @@ public class Video {
 
     }
 
+    public Video(String title, Long memberId, Long categoryId, String uniqueFileName) {
+        this.title = title;
+        this.memberId = memberId;
+        this.categoryId = categoryId;
+        this.uniqueFileName = uniqueFileName;
+    }
+
     public Long getId() {
         return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getUniqueFileName() {
+        return uniqueFileName;
+    }
+
+    public Long getCategoryId() {
+        return categoryId;
     }
 
     public void incrementLikes() {
@@ -52,5 +71,9 @@ public class Video {
 
     public void decrementLikes() {
         this.countLikes--;
+    }
+
+    public Long getMemberId() {
+        return memberId;
     }
 }

--- a/src/main/java/ojosama/talkak/video/service/AwsS3Service.java
+++ b/src/main/java/ojosama/talkak/video/service/AwsS3Service.java
@@ -3,45 +3,83 @@ package ojosama.talkak.video.service;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import ojosama.talkak.category.repository.CategoryRepository;
+import ojosama.talkak.common.exception.TalKakException;
+import ojosama.talkak.common.exception.code.VideoError;
 import ojosama.talkak.video.dto.AwsS3Request;
 import ojosama.talkak.video.dto.AwsS3Response;
+import ojosama.talkak.video.dto.VideoRequest;
+import ojosama.talkak.video.dto.VideoResponse;
+import ojosama.talkak.video.model.Video;
+import ojosama.talkak.video.repository.VideoRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class AwsS3Service {
 
     private final AmazonS3 amazonS3;
+    private final VideoRepository videoRepository;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
+    public VideoResponse uploadVideo(MultipartFile file, VideoRequest videoRequest)
+        throws IOException {
+        String fileName = file.getOriginalFilename();
+        amazonS3.putObject(new PutObjectRequest(bucket, fileName, file.getInputStream(), null));
+        Video video = new Video(videoRequest.title(), videoRequest.memberId(),
+            videoRequest.categoryId(), fileName);
+        video = videoRepository.save(video);
+        return new VideoResponse(video.getId(), video.getTitle(), video.getMemberId(),
+            video.getCategoryId(), video.getUniqueFileName());
+    }
+
+    public URL generateDownloadUrl(Long id) throws MalformedURLException {
+        Video video = videoRepository.findById(id)
+            .orElseThrow(() -> TalKakException.of(VideoError.INVALID_VIDEO_ID));
+        AwsS3Request request = new AwsS3Request(video.getUniqueFileName());
+        AwsS3Response response = getPresignedUrlToDownload(request);
+        return new URL(response.url());
+    }
+
     public AwsS3Response getPresignedUrlToUpload(AwsS3Request request) {
-        GeneratePresignedUrlRequest presignedUrlRequest = generatePresignedUrlRequest(request, HttpMethod.PUT);
+        GeneratePresignedUrlRequest presignedUrlRequest = generatePresignedUrlRequest(request,
+            HttpMethod.PUT);
         return new AwsS3Response(amazonS3.generatePresignedUrl(presignedUrlRequest).toString());
     }
 
     public AwsS3Response getPresignedUrlToDownload(AwsS3Request request) {
-        GeneratePresignedUrlRequest presignedUrlRequest = generatePresignedUrlRequest(request, HttpMethod.GET);
+        GeneratePresignedUrlRequest presignedUrlRequest = generatePresignedUrlRequest(request,
+            HttpMethod.GET);
         return new AwsS3Response(amazonS3.generatePresignedUrl(presignedUrlRequest).toString());
     }
 
     public AwsS3Response getPresignedUrlToDelete(AwsS3Request request) {
-        GeneratePresignedUrlRequest presignedUrlRequest = generatePresignedUrlRequest(request, HttpMethod.DELETE);
+        GeneratePresignedUrlRequest presignedUrlRequest = generatePresignedUrlRequest(request,
+            HttpMethod.DELETE);
         return new AwsS3Response(amazonS3.generatePresignedUrl(presignedUrlRequest).toString());
     }
 
-    public GeneratePresignedUrlRequest generatePresignedUrlRequest(AwsS3Request request, HttpMethod httpMethod) {
+    public GeneratePresignedUrlRequest generatePresignedUrlRequest(AwsS3Request request,
+        HttpMethod httpMethod) {
         String filename = request.filename();
         Date expirationTime = getExpirationTime();
-        GeneratePresignedUrlRequest presignedUrlRequest = new GeneratePresignedUrlRequest(bucket, filename)
-                .withMethod(httpMethod)
-                .withExpiration(expirationTime);
+        GeneratePresignedUrlRequest presignedUrlRequest = new GeneratePresignedUrlRequest(bucket,
+            filename)
+            .withMethod(httpMethod)
+            .withExpiration(expirationTime);
         return presignedUrlRequest;
     }
 


### PR DESCRIPTION
### 🛠️ 작업 내용
영상 업로드와 다운로드 기능을 구현했습니다.

### 💡 참고 사항
현재 예상되는 흐름은 다음과 같습니다.
1) AI 서버쪽에서 쇼츠 영상을 반환
2) 반환된 파일을 자바측 서버의 API 호출 = 자바 서버로 multipartFile 타입으로 쇼츠 영상 전송
3) multipartFile 을 S3 에 upload 하고 Video Entity 생성 + VideoResponse DTO 반환

그리고 영상을 다운로드하는 기능을 구현할 때, S3 의 presignedUrl 을 사용하게끔 했습니다.
이때 VideoEntity 의 `videoUrl` 이라는 내부변수에 만약 S3 에 저장된 url 을 그대로 사용하는 경우 보안상의 문제가 있을 것 같아 해당 부분을 `uniqueFileName` 이라는 내부변수로 변경했습니다. 이는 S3 에 업로드하거나 S3 에서 다운로드할 때 사용되는 키값이 됩니다. 물론 이 경우 **2) 변환된 파일을 자바측 서버의 API 호출** 단계에서 `fileName` 을 UUID 혹은 생성일자 등과 같은 방법을 사용하여 unique 한 값이 되도록해줘야할 것입니다.


### 🚨 현재 버그
X


### 💡 Week5 Review 질문 사항
현재 예상되는 흐름은 다음과 같습니다.

1) AI 서버쪽에서 쇼츠 영상을 반환
2) 반환된 파일을 자바측 서버의 API 호출 = 자바 서버로 multipartFile 타입으로 쇼츠 영상 전송
3) multipartFile 을 S3 에 upload 하고 Video Entity 생성 + VideoResponse DTO 반환
그리고 영상을 다운로드하는 기능을 구현할 때, S3 의 presignedUrl 을 사용하게끔 했습니다.
이때 `Video` Entity 의 `videoUrl` 이라는 내부변수에 만약 S3 에 저장된 url 을 그대로 사용하는 경우 보안상의 문제가 있을 것 같아 해당 부분을 `uniqueFileName` 이라는 내부변수로 변경했습니다. 이는 S3 에 업로드하거나 S3 에서 다운로드할 때 사용되는 키값이 됩니다. 물론 이 경우 2) 변환된 파일을 자바측 서버의 API 호출 단계에서 fileName 을 UUID 혹은 생성일자 등과 같은 방법을 사용하여 unique 한 값이 되도록 해줘야 할 것입니다.

그런데 이렇게 구현하는 경우, 홈화면 등에서 여러개의 `Video` Entity 를 보여줄 때, S3 에 `uniqueFileName` 을 사용하여 PresignedUrl 을 일일히 받아야 하는 문제점이 있습니다... 결국 `Video` Entity 에 S3 에 저장되는 url 을 내부변수로 가지게 해야할까요? 또한 프론트엔드 측에서 유튜브 홈화면처럼 한번에 여러개의 영상을 보여주려고 한다면 결국 원본 영상의 url  노출은 어쩔수 없는건가요?


### ☑️ Git Close
#33 
---