### PR TITLE
영상기록 관련 엔티티, Repository, Service 구현

### DIFF
--- a/src/main/java/ojosama/talkak/comment/service/CommentService.java
+++ b/src/main/java/ojosama/talkak/comment/service/CommentService.java
@@ -29,13 +29,14 @@ public class CommentService {
         this.videoRepository = videoRepository;
     }
 
-    public CommentResponse createComment(long memberId, long videoId, CommentRequest commentRequest) {
+    public CommentResponse createComment(long memberId, long videoId,
+        CommentRequest commentRequest) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> TalKakException.of(CommentError.INVALID_MEMBER_ID));
         Video video = videoRepository.findById(videoId)
             .orElseThrow(() -> TalKakException.of(CommentError.INVALID_VIDEO_ID));
-        Comment comment = new Comment(member, video, commentRequest.content());
-        return convertToDTO(commentRepository.save(comment));
+        return convertToDTO(
+            commentRepository.save(new Comment(member, video, commentRequest.content())));
     }
 
     public List<CommentResponse> getCommentsByVideoId(long videoId) {
@@ -45,7 +46,8 @@ public class CommentService {
             .toList();
     }
 
-    public CommentResponse updateComment(Long commentId, Long memberId, CommentRequest commentRequest) {
+    public CommentResponse updateComment(Long commentId, Long memberId,
+        CommentRequest commentRequest) {
         Comment comment = commentRepository.findById(commentId)
             .orElseThrow(() -> TalKakException.of(CommentError.INVALID_COMMENT_ID));
         if (!Objects.equals(comment.getMember().getId(), memberId)) {

--- a/src/main/java/ojosama/talkak/common/exception/code/VideoError.java
+++ b/src/main/java/ojosama/talkak/common/exception/code/VideoError.java
@@ -8,7 +8,8 @@ public enum VideoError implements ErrorCode {
 
     /* 400 Bad Request */
     INVALID_VIDEO_ID(HttpStatus.BAD_REQUEST, "V001", "유효하지 않은 videoId입니다."),
-    YOUTUBE_API_BAD_REQUEST(HttpStatus.BAD_REQUEST, "V002", "유효하지 않은 유튜브 요청입니다.");
+    YOUTUBE_API_BAD_REQUEST(HttpStatus.BAD_REQUEST, "V002", "유효하지 않은 유튜브 요청입니다."),
+    S3_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "V003", "S3에 업로드 실패했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/ojosama/talkak/reaction/domain/Reaction.java
+++ b/src/main/java/ojosama/talkak/reaction/domain/Reaction.java
@@ -26,6 +26,9 @@ public class Reaction {
     @JoinColumn(name = "video_id", insertable = false, updatable = false)
     private Video video;
 
+    public Reaction() {
+    }
+
     public Reaction(ReactionId reactionId, Member member, Video video, boolean reactionType) {
         this.id = reactionId;
         this.member = member;

--- a/src/main/java/ojosama/talkak/video/domain/Video.java
+++ b/src/main/java/ojosama/talkak/video/domain/Video.java
@@ -32,6 +32,7 @@ public class Video {
     private String thumbnail;
     private Boolean isPublic;
     private Long countLikes;
+    private Long views = 0L;
     @OneToMany(mappedBy = "video", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Comment> comments;
 
@@ -79,5 +80,9 @@ public class Video {
 
     public Long getMemberId() {
         return memberId;
+    }
+
+    public void incrementViews() {
+        this.views += 1;
     }
 }

--- a/src/main/java/ojosama/talkak/video/domain/Video.java
+++ b/src/main/java/ojosama/talkak/video/domain/Video.java
@@ -35,6 +35,10 @@ public class Video {
     @OneToMany(mappedBy = "video", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Comment> comments;
 
+    public Video() {
+
+    }
+
     public Video(Long id, String title, Long countLikes) {
         this.id = id;
         this.title = title;

--- a/src/main/java/ojosama/talkak/viewingRecord/domain/ViewingRecord.java
+++ b/src/main/java/ojosama/talkak/viewingRecord/domain/ViewingRecord.java
@@ -1,0 +1,43 @@
+package ojosama.talkak.viewingRecord.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import ojosama.talkak.member.domain.Member;
+import ojosama.talkak.video.domain.Video;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "viewing_records")
+public class ViewingRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "video_id", nullable = false)
+    private Video video;
+
+    @CreationTimestamp
+    private LocalDateTime viewedAt;
+
+    public ViewingRecord() {
+
+    }
+
+    public ViewingRecord(Member member, Video video) {
+        this.member = member;
+        this.video = video;
+    }
+}

--- a/src/main/java/ojosama/talkak/viewingRecord/repository/ViewingRecordRepository.java
+++ b/src/main/java/ojosama/talkak/viewingRecord/repository/ViewingRecordRepository.java
@@ -1,0 +1,10 @@
+package ojosama.talkak.viewingRecord.repository;
+
+import ojosama.talkak.viewingRecord.domain.ViewingRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ViewingRecordRepository extends JpaRepository<ViewingRecord, Long> {
+
+}

--- a/src/main/java/ojosama/talkak/viewingRecord/service/ViewingRecordService.java
+++ b/src/main/java/ojosama/talkak/viewingRecord/service/ViewingRecordService.java
@@ -1,0 +1,41 @@
+package ojosama.talkak.viewingRecord.service;
+
+import ojosama.talkak.common.exception.TalKakException;
+import ojosama.talkak.common.exception.code.MemberError;
+import ojosama.talkak.common.exception.code.VideoError;
+import ojosama.talkak.member.domain.Member;
+import ojosama.talkak.member.repository.MemberRepository;
+import ojosama.talkak.video.domain.Video;
+import ojosama.talkak.video.repository.VideoRepository;
+import ojosama.talkak.viewingRecord.domain.ViewingRecord;
+import ojosama.talkak.viewingRecord.repository.ViewingRecordRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ViewingRecordService {
+
+    private final ViewingRecordRepository viewingRecordRepository;
+    private final MemberRepository memberRepository;
+    private final VideoRepository videoRepository;
+
+    public ViewingRecordService(ViewingRecordRepository viewingRecordRepository,
+        MemberRepository memberRepository, VideoRepository videoRepository) {
+        this.viewingRecordRepository = viewingRecordRepository;
+        this.memberRepository = memberRepository;
+        this.videoRepository = videoRepository;
+    }
+
+    @Transactional
+    public void incrementViewsAndCreateRecord(Long videoId, Long memberId) {
+        Video video = videoRepository.findById(videoId)
+            .orElseThrow(() -> TalKakException.of(VideoError.INVALID_VIDEO_ID));
+
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> TalKakException.of(MemberError.NOT_EXISTING_MEMBER));
+
+        viewingRecordRepository.save(new ViewingRecord(member, video));
+        video.incrementViews();
+    }
+
+}


### PR DESCRIPTION
### 🛠️ 작업 내용
- 유저의 반응을 관리하는 `Reaction` Entity 의 저장 로직 순서 변경
- `Video` Entity 의 조회수, `views` 내부 변수 정의 (기본값 `0L`)
- 최근 본 영상처럼 내가 본 영상들을 관리할 수 있게끔, `ViewingRecord` 엔티티 구현

### 💡 참고 사항
- `ViewingRecordService` 에 `@Transactional` 사용하여 `ViewingRecord` 엔티티가 생성됨과 동시에 `Member` 와 `Video` 엔티티를 내부변수로 갖게끔 했고, `Video` 엔티티의 조회수를 1 증가시키게끔 했습니다.

### 🚨 현재 버그

---

### ☑️ Git Close
#47 
---