### PR TITLE
마이페이지 API 스웨거 배포

### DIFF
--- a/src/main/java/ojosama/talkak/member/controller/MemberApiController.java
+++ b/src/main/java/ojosama/talkak/member/controller/MemberApiController.java
@@ -6,11 +6,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import ojosama.talkak.common.exception.ErrorResponse;
 import ojosama.talkak.member.dto.AdditionalInfoRequest;
 import ojosama.talkak.member.dto.AdditionalInfoResponse;
+import ojosama.talkak.member.dto.MyPageInfoRequest;
+import ojosama.talkak.member.dto.MyPageInfoResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "회원 정보 API", description = "회원 정보 관련 API를 담당합니다.")
 public interface MemberApiController {
@@ -21,5 +25,25 @@ public interface MemberApiController {
             @ApiResponse(responseCode = "M001", description = "존재하지 않는 회원입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "M002", description = "회원 정보를 수정하는 데 오류가 발생하였습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<AdditionalInfoResponse> updateAdditionalInfo(AdditionalInfoRequest request, Authentication authentication);
+    ResponseEntity<AdditionalInfoResponse> updateAdditionalInfo(AdditionalInfoRequest request,
+        Authentication authentication);
+
+    @Operation(summary = "마이페이지 조회", description = "마이페이지의 개인 정보를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "마이페이지 조회 성공"),
+        @ApiResponse(responseCode = "M001", description = "존재하지 않는 회원",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    ResponseEntity<MyPageInfoResponse> getMemberInfo(Authentication authentication);
+
+    @Operation(summary = "마이페이지 수정", description = "마이페이지의 개인 정보를 수정합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "마이페이지 수정 성공"),
+        @ApiResponse(responseCode = "M001", description = "존재하지 않는 회원",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "M002", description = "회원 정보 수정 과정에서 오류 발생",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<MyPageInfoResponse> updateMemberInfo(@RequestBody @Valid MyPageInfoRequest myPageInfoRequest, Authentication authentication);
+
 }

--- a/src/main/java/ojosama/talkak/member/controller/MemberController.java
+++ b/src/main/java/ojosama/talkak/member/controller/MemberController.java
@@ -25,15 +25,15 @@ public class MemberController implements MemberApiController {
     private final MemberService memberService;
 
     @GetMapping("/me")
-    public ResponseEntity<MyPageInfoResponse> getMemberInfo() {
-        Long memberId = 1L; //추후 로그인 기능 구현 시 수정 예정
+    public ResponseEntity<MyPageInfoResponse> getMemberInfo(Authentication authentication) {
+        Long memberId = Long.valueOf(authentication.getPrincipal().toString());
         MyPageInfoResponse memberInfo = memberService.getMemberInfo(memberId);
         return new ResponseEntity<>(memberInfo, HttpStatus.OK);
     }
 
     @PutMapping("/me")
-    public ResponseEntity<MyPageInfoResponse> updateMemberInfo(@RequestBody @Valid MyPageInfoRequest myPageInfoRequest) {
-        Long memberId = 1L;
+    public ResponseEntity<MyPageInfoResponse> updateMemberInfo(@RequestBody @Valid MyPageInfoRequest myPageInfoRequest, Authentication authentication) {
+        Long memberId = Long.valueOf(authentication.getPrincipal().toString());
         MyPageInfoResponse memberInfo = memberService.updateMemberInfo(memberId, myPageInfoRequest);
         return new ResponseEntity<>(memberInfo, HttpStatus.OK);
     }

--- a/src/test/java/ojosama/talkak/member/service/MemberServiceTest.java
+++ b/src/test/java/ojosama/talkak/member/service/MemberServiceTest.java
@@ -106,16 +106,16 @@ class MemberServiceTest {
     @Test
     void invalid_input_gender() {
         assertErrorCode(MemberError.ERROR_UPDATE_MEMBER_INFO,
-            () -> memberService.updateMemberInfo(member.getId(), createGender(null)));
+            () -> updateMemberInfoTest(member.getId(), createGender(null)));
 
         assertErrorCode(MemberError.ERROR_UPDATE_MEMBER_INFO,
-            () -> memberService.updateMemberInfo(member.getId(), createGender("")));
+            () -> updateMemberInfoTest(member.getId(), createGender("")));
 
         assertErrorCode(MemberError.ERROR_UPDATE_MEMBER_INFO,
-            () -> memberService.updateMemberInfo(member.getId(), createGender("남자 ")));
+            () -> updateMemberInfoTest(member.getId(), createGender("남자 ")));
 
         assertErrorCode(MemberError.ERROR_UPDATE_MEMBER_INFO,
-            () -> memberService.updateMemberInfo(member.getId(), createGender("남자, 여자")));
+            () -> updateMemberInfoTest(member.getId(), createGender("남자, 여자")));
     }
 
     @DisplayName("마이페이지 개인정보 수정하기 실패-유효하지 않은 나이 정보")
@@ -125,50 +125,54 @@ class MemberServiceTest {
             () -> memberService.updateMemberInfo(member.getId(), createAge(null)));
 
         assertErrorCode(MemberError.ERROR_UPDATE_MEMBER_INFO,
-            () -> memberService.updateMemberInfo(member.getId(), createAge("")));
+            () -> updateMemberInfoTest(member.getId(), createAge("")));
 
         assertErrorCode(MemberError.ERROR_UPDATE_MEMBER_INFO,
-            () -> memberService.updateMemberInfo(member.getId(), createAge("10")));
+            () -> updateMemberInfoTest(member.getId(), createAge("10")));
 
         assertErrorCode(MemberError.ERROR_UPDATE_MEMBER_INFO,
-            () -> memberService.updateMemberInfo(member.getId(), createAge("10대 ")));
+            () -> updateMemberInfoTest(member.getId(), createAge("10대 ")));
 
         assertErrorCode(MemberError.ERROR_UPDATE_MEMBER_INFO,
-            () -> memberService.updateMemberInfo(member.getId(), createAge("10대.")));
+            () -> updateMemberInfoTest(member.getId(), createAge("10대.")));
 
         assertErrorCode(MemberError.ERROR_UPDATE_MEMBER_INFO,
-            () -> memberService.updateMemberInfo(member.getId(), createAge("60대")));
+            () -> updateMemberInfoTest(member.getId(), createAge("60대")));
 
         assertErrorCode(MemberError.ERROR_UPDATE_MEMBER_INFO,
-            () -> memberService.updateMemberInfo(member.getId(), createAge("50대이상")));
+            () -> updateMemberInfoTest(member.getId(), createAge("50대이상")));
     }
 
     @DisplayName("마이페이지 개인정보 수정하기 실패-유효하지 않은 카테고리 옵션")
     @Test
     void invalid_input_categories() {
         assertErrorCode(MemberError.ERROR_UPDATE_MEMBER_INFO,
-            () -> memberService.updateMemberInfo(member.getId(),
+            () -> updateMemberInfoTest(member.getId(),
                 createCategories(List.of("", "", ""))));
 
         assertErrorCode(MemberError.ERROR_UPDATE_MEMBER_INFO,
-            () -> memberService.updateMemberInfo(member.getId(),
+            () -> updateMemberInfoTest(member.getId(),
                 createCategories(List.of("음식"))));
 
         assertErrorCode(MemberError.ERROR_UPDATE_MEMBER_INFO,
-            () -> memberService.updateMemberInfo(member.getId(),
+            () -> updateMemberInfoTest(member.getId(),
                 createCategories(List.of("음식", "음악"))));
 
         assertErrorCode(MemberError.ERROR_UPDATE_MEMBER_INFO,
-            () -> memberService.updateMemberInfo(member.getId(),
+            () -> updateMemberInfoTest(member.getId(),
                 createCategories(List.of("음식", "음악", "여행", "게임"))));
 
         assertErrorCode(MemberError.ERROR_UPDATE_MEMBER_INFO,
-            () -> memberService.updateMemberInfo(member.getId(),
+            () -> updateMemberInfoTest(member.getId(),
                 createCategories(List.of("음식", "음악", "음악"))));
 
         assertErrorCode(MemberError.ERROR_UPDATE_MEMBER_INFO,
-            () -> memberService.updateMemberInfo(member.getId(),
+            () -> updateMemberInfoTest(member.getId(),
                 createCategories(List.of("음식", "음악", "여행 "))));
+    }
+
+    private void updateMemberInfoTest(Long id, MyPageInfoRequest request) {
+        memberService.updateMemberInfo(id, request);
     }
 
     private MyPageInfoRequest createGender(String gender) {


### PR DESCRIPTION
### 🛠️ 작업 내용

---
마이페이지 API(회원정보 조회, 회원정보 수정) 스웨거 적용하였습니다.
### 💡 참고 사항

---

### 🚨 현재 버그

---
API 응답으로 500 에러가 발생합니다. 로그를 보니 해당 로직에서 에러가 발생하는 것으로 보입니다.
```
Long.valueOf(authentication.getPrincipal().toString());
```
### ☑️ Git Close

---
- close #64 