### PR TITLE
조회수/좋아요수 동시성 제어 기능 추가

### DIFF
--- a/src/main/java/ojosama/talkak/common/exception/code/ReactionError.java
+++ b/src/main/java/ojosama/talkak/common/exception/code/ReactionError.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 public enum ReactionError implements ErrorCode {
     UNAUTHORIZED_USER(HttpStatus.BAD_REQUEST, "R001", "인증되지 않은 유저입니다."),
     INVALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "R002", "유효하지 않은 memberId 입니다."),
-    INVALID_VIDEO_ID(HttpStatus.BAD_REQUEST, "R003", "유효하지 않은 videoID 입니다.");
+    INVALID_VIDEO_ID(HttpStatus.BAD_REQUEST, "R003", "유효하지 않은 videoID 입니다."),
+    FAILED_PROCESS_REQUEST(HttpStatus.BAD_REQUEST, "R004", "좋아요 요청 처리에 실패하였습니다. 다시 시도해주세요.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/ojosama/talkak/reaction/service/ReactionService.java
+++ b/src/main/java/ojosama/talkak/reaction/service/ReactionService.java
@@ -18,20 +18,14 @@ import org.springframework.stereotype.Service;
 public class ReactionService {
 
     private final ReactionsRepository reactionsRepository;
-    private final MemberRepository memberRepository;
-    private final VideoRepository videoRepository;
     private final RedisService redisService;
     private final RedisTemplate<String, Object> redisTemplate;
     private final HashConverter hashConverter;
 
-    public ReactionService(ReactionsRepository reactionsRepository,
-        MemberRepository memberRepository,
-        VideoRepository videoRepository, RedisService redisService,
+    public ReactionService(ReactionsRepository reactionsRepository, RedisService redisService,
         RedisTemplate<String, Object> redisTemplate,
         HashConverter hashConverter) {
         this.reactionsRepository = reactionsRepository;
-        this.memberRepository = memberRepository;
-        this.videoRepository = videoRepository;
         this.redisService = redisService;
         this.redisTemplate = redisTemplate;
         this.hashConverter = hashConverter;

--- a/src/main/java/ojosama/talkak/reaction/service/ReactionService.java
+++ b/src/main/java/ojosama/talkak/reaction/service/ReactionService.java
@@ -7,8 +7,14 @@ import ojosama.talkak.member.repository.MemberRepository;
 import ojosama.talkak.reaction.domain.Reaction;
 import ojosama.talkak.reaction.domain.ReactionId;
 import ojosama.talkak.reaction.repository.ReactionRepository;
+import ojosama.talkak.redis.HashConverter;
+import ojosama.talkak.redis.RedisService;
+import ojosama.talkak.redis.domain.VideoInfo;
+import ojosama.talkak.redis.innerkey.VideoHashKey;
+import ojosama.talkak.redis.key.VideoKey;
 import ojosama.talkak.video.domain.Video;
 import ojosama.talkak.video.repository.VideoRepository;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,12 +23,19 @@ public class ReactionService {
     private final ReactionRepository reactionRepository;
     private final MemberRepository memberRepository;
     private final VideoRepository videoRepository;
+    private final RedisService redisService;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final HashConverter hashConverter;
 
     public ReactionService(ReactionRepository reactionRepository, MemberRepository memberRepository,
-        VideoRepository videoRepository) {
+        VideoRepository videoRepository, RedisService redisService, RedisTemplate<String, Object> redisTemplate,
+        HashConverter hashConverter) {
         this.reactionRepository = reactionRepository;
         this.memberRepository = memberRepository;
         this.videoRepository = videoRepository;
+        this.redisService = redisService;
+        this.redisTemplate = redisTemplate;
+        this.hashConverter = hashConverter;
     }
 
     public void toggleLike(Long videoId, Long memberId) {
@@ -42,6 +55,19 @@ public class ReactionService {
                 }
             );
     }
+
+    public VideoInfo incrementViewCount(Long categoryId, Long videoId) {
+        String key = VideoKey.VIDEO_INFO.generateKey(categoryId, videoId);
+        redisTemplate.opsForHash().increment(key, VideoHashKey.VIEW_COUNT.getKey(), 1);
+        return hashConverter.FromMap(redisService.getHashOps(key), VideoInfo.class);
+    }
+
+    public VideoInfo incrementLikeCount(Long categoryId, Long videoId) {
+        String key = VideoKey.VIDEO_INFO.generateKey(categoryId, videoId);
+        redisTemplate.opsForHash().increment(key, VideoHashKey.LIKE_COUNT.getKey(), 1);
+        return hashConverter.FromMap(redisService.getHashOps(key), VideoInfo.class);
+    }
+
 
     private void removeExistingReactionAndUpdateLikes(Reaction existingReaction, Video video) {
         reactionRepository.delete(existingReaction);

--- a/src/main/java/ojosama/talkak/redis/domain/Reactions.java
+++ b/src/main/java/ojosama/talkak/redis/domain/Reactions.java
@@ -21,7 +21,7 @@ public class Reactions {
         return new Reactions(watched, liked);
     }
 
-    public void toggleLike() {
+    public void updateLike() {
         this.liked = Math.abs(liked - 1);
     }
 

--- a/src/main/java/ojosama/talkak/redis/domain/VideoInfo.java
+++ b/src/main/java/ojosama/talkak/redis/domain/VideoInfo.java
@@ -27,12 +27,4 @@ public class VideoInfo {
             viewCount, likeCount);
     }
 
-    public void incrementViewCount() {
-        this.viewCount++;
-    }
-
-    public void incrementLikeCount() {
-        this.likeCount++;
-    }
-
 }

--- a/src/main/java/ojosama/talkak/redis/repository/ReactionsRepository.java
+++ b/src/main/java/ojosama/talkak/redis/repository/ReactionsRepository.java
@@ -1,5 +1,7 @@
 package ojosama.talkak.redis.repository;
 
+import java.util.Map;
+import java.util.Optional;
 import ojosama.talkak.redis.HashConverter;
 import ojosama.talkak.redis.RedisService;
 import ojosama.talkak.redis.domain.Reactions;
@@ -24,16 +26,17 @@ public class ReactionsRepository {
         return hashConverter.FromMap(redisService.getHashOps(key), Reactions.class);
     }
 
-    public Reactions findByMemberIdAndVideoId(Long memberId, Long videoId) {
+    public Optional<Reactions> findByMemberIdAndVideoId(Long memberId, Long videoId) {
         String key = ReactionKey.REACTION.generateKey(memberId, videoId);
-        return hashConverter.FromMap(redisService.getHashOps(key), Reactions.class);
+        Map<String, Object> entries = redisService.getHashOps(key);
+
+        if (entries.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(hashConverter.FromMap(entries, Reactions.class));
     }
 
-    public Reactions updateLiked(Long memberId, Long videoId, Integer liked) {
-        String key = ReactionKey.REACTION.generateKey(memberId, videoId);
-        redisService.setHashValue(key, ReactionHashKey.LIKED.getKey(), liked);
-        return hashConverter.FromMap(redisService.getHashOps(key), Reactions.class);
-    }
 
     public void delete(Long memberId, Long videoId) {
         String key = ReactionKey.REACTION.generateKey(memberId, videoId);

--- a/src/main/java/ojosama/talkak/redis/repository/UserMetaRepository.java
+++ b/src/main/java/ojosama/talkak/redis/repository/UserMetaRepository.java
@@ -1,6 +1,8 @@
 package ojosama.talkak.redis.repository;
 
 import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
 import ojosama.talkak.redis.HashConverter;
 import ojosama.talkak.redis.RedisService;
 import ojosama.talkak.redis.domain.UserMeta;
@@ -25,9 +27,15 @@ public class UserMetaRepository {
         return hashConverter.FromMap(redisService.getHashOps(key), UserMeta.class);
     }
 
-    public UserMeta findByMemberId(Long memberId) {
+    public Optional<UserMeta> findByMemberId(Long memberId) {
         String key = UserMetaKey.USER_META.generateKey(memberId);
-        return hashConverter.FromMap(redisService.getHashOps(key), UserMeta.class);
+        Map<String, Object> entries = redisService.getHashOps(key);
+
+        if(entries.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(hashConverter.FromMap(entries, UserMeta.class));
     }
 
     public UserMeta updateLastUpdatedAt(Long memberId, LocalDateTime dateTime) {

--- a/src/main/java/ojosama/talkak/redis/repository/VideoInfoRepository.java
+++ b/src/main/java/ojosama/talkak/redis/repository/VideoInfoRepository.java
@@ -1,5 +1,7 @@
 package ojosama.talkak.redis.repository;
 
+import java.util.Map;
+import java.util.Optional;
 import ojosama.talkak.redis.HashConverter;
 import ojosama.talkak.redis.RedisService;
 import ojosama.talkak.redis.domain.VideoInfo;
@@ -25,9 +27,15 @@ public class VideoInfoRepository {
         return hashConverter.FromMap(redisService.getHashOps(key), VideoInfo.class);
     }
 
-    public VideoInfo findByCategoryAndVideoId(Long categoryId, Long videoId) {
+    public Optional<VideoInfo> findByCategoryAndVideoId(Long categoryId, Long videoId) {
         String key = VideoKey.VIDEO_INFO.generateKey(categoryId, videoId);
-        return hashConverter.FromMap(redisService.getHashOps(key), VideoInfo.class);
+        Map<String, Object> entries = redisService.getHashOps(key);
+
+        if (entries.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(hashConverter.FromMap(entries, VideoInfo.class));
     }
 
     public void delete(Long categoryId, Long videoId) {

--- a/src/main/java/ojosama/talkak/redis/repository/VideoInfoRepository.java
+++ b/src/main/java/ojosama/talkak/redis/repository/VideoInfoRepository.java
@@ -5,6 +5,7 @@ import ojosama.talkak.redis.RedisService;
 import ojosama.talkak.redis.domain.VideoInfo;
 import ojosama.talkak.redis.innerkey.VideoHashKey;
 import ojosama.talkak.redis.key.VideoKey;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -26,18 +27,6 @@ public class VideoInfoRepository {
 
     public VideoInfo findByCategoryAndVideoId(Long categoryId, Long videoId) {
         String key = VideoKey.VIDEO_INFO.generateKey(categoryId, videoId);
-        return hashConverter.FromMap(redisService.getHashOps(key), VideoInfo.class);
-    }
-
-    public VideoInfo updateViewCount(Long categoryId, Long videoId, Long updatedViewCount) {
-        String key = VideoKey.VIDEO_INFO.generateKey(categoryId, videoId);
-        redisService.setHashValue(key, VideoHashKey.VIEW_COUNT.getKey(), updatedViewCount);
-        return hashConverter.FromMap(redisService.getHashOps(key), VideoInfo.class);
-    }
-
-    public VideoInfo updateLikeCount(Long categoryId, Long videoId, Long updatedLikeCount) {
-        String key = VideoKey.VIDEO_INFO.generateKey(categoryId, videoId);
-        redisService.setHashValue(key, VideoHashKey.LIKE_COUNT.getKey(), updatedLikeCount);
         return hashConverter.FromMap(redisService.getHashOps(key), VideoInfo.class);
     }
 

--- a/src/test/java/ojosama/talkak/redis/repository/VideoInfoConcurrencyTest.java
+++ b/src/test/java/ojosama/talkak/redis/repository/VideoInfoConcurrencyTest.java
@@ -1,6 +1,7 @@
 package ojosama.talkak.redis.repository;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -56,9 +57,9 @@ class VideoInfoConcurrencyTest {
         }
 
         latch.await();
-        VideoInfo updatedViewInfo = videoInfoRepository.findByCategoryAndVideoId(categoryId,
+        Optional<VideoInfo> updatedViewInfo = videoInfoRepository.findByCategoryAndVideoId(categoryId,
             videoId);
-        Assertions.assertThat(updatedViewInfo.getViewCount()).isEqualTo(Long.valueOf(threadCount));
+        Assertions.assertThat(updatedViewInfo.get().getViewCount()).isEqualTo(Long.valueOf(threadCount));
     }
 
     @DisplayName("좋아요수 동시성 테스트")
@@ -76,9 +77,9 @@ class VideoInfoConcurrencyTest {
         }
 
         latch.await();
-        VideoInfo updatedViewInfo = videoInfoRepository.findByCategoryAndVideoId(categoryId,
+        Optional<VideoInfo> updatedViewInfo = videoInfoRepository.findByCategoryAndVideoId(categoryId,
             videoId);
-        Assertions.assertThat(updatedViewInfo.getLikeCount()).isEqualTo(Long.valueOf(threadCount));
+        Assertions.assertThat(updatedViewInfo.get().getLikeCount()).isEqualTo(Long.valueOf(threadCount));
     }
 
 }

--- a/src/test/java/ojosama/talkak/redis/repository/VideoInfoConcurrencyTest.java
+++ b/src/test/java/ojosama/talkak/redis/repository/VideoInfoConcurrencyTest.java
@@ -1,0 +1,84 @@
+package ojosama.talkak.redis.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import lombok.extern.slf4j.Slf4j;
+import ojosama.talkak.redis.config.RecommendTestContainerConfig;
+import ojosama.talkak.redis.config.RedisTestContainerConfig;
+import ojosama.talkak.redis.domain.VideoInfo;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@SpringBootTest
+@Slf4j
+@ExtendWith({RedisTestContainerConfig.class, RecommendTestContainerConfig.class})
+class VideoInfoConcurrencyTest {
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired
+    private VideoInfoRepository videoInfoRepository;
+
+    private VideoInfo videoInfo;
+    private Long categoryId = 1L;
+    private Long videoId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        videoInfo = videoInfoRepository.save(categoryId, videoId, VideoInfo.of(LocalDateTime.now(), 0L, 0L));
+    }
+
+    @DisplayName("조회수 동시성 테스트")
+    @Test
+    void views_concurrency_test() throws InterruptedException {
+        int threadCount = 1243;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for(int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                videoInfo.incrementViewCount();
+                videoInfoRepository.updateViewCount(categoryId, videoId, videoInfo.getViewCount());
+                latch.countDown();
+            });
+        }
+
+        latch.await();
+        VideoInfo updatedViewInfo = videoInfoRepository.findByCategoryAndVideoId(categoryId,
+            videoId);
+        Assertions.assertThat(updatedViewInfo.getViewCount()).isEqualTo(Long.valueOf(threadCount));
+    }
+
+    @DisplayName("좋아요수 동시성 테스트")
+    @Test
+    void likes_concurrency_test() throws InterruptedException {
+        int threadCount = 1496;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for(int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                videoInfo.incrementLikeCount();
+                videoInfoRepository.updateLikeCount(categoryId, videoId, videoInfo.getLikeCount());
+                latch.countDown();
+            });
+        }
+
+        latch.await();
+        VideoInfo updatedViewInfo = videoInfoRepository.findByCategoryAndVideoId(categoryId,
+            videoId);
+        Assertions.assertThat(updatedViewInfo.getLikeCount()).isEqualTo(Long.valueOf(threadCount));
+    }
+
+}

--- a/src/test/java/ojosama/talkak/redis/repository/VideoInfoConcurrencyTest.java
+++ b/src/test/java/ojosama/talkak/redis/repository/VideoInfoConcurrencyTest.java
@@ -1,12 +1,11 @@
 package ojosama.talkak.redis.repository;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.time.LocalDateTime;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import lombok.extern.slf4j.Slf4j;
+import ojosama.talkak.reaction.service.ReactionService;
 import ojosama.talkak.redis.config.RecommendTestContainerConfig;
 import ojosama.talkak.redis.config.RedisTestContainerConfig;
 import ojosama.talkak.redis.domain.VideoInfo;
@@ -26,6 +25,9 @@ class VideoInfoConcurrencyTest {
 
     @Autowired
     private RedisTemplate<String, Object> redisTemplate;
+
+    @Autowired
+    private ReactionService reactionService;
 
     @Autowired
     private VideoInfoRepository videoInfoRepository;
@@ -48,8 +50,7 @@ class VideoInfoConcurrencyTest {
 
         for(int i = 0; i < threadCount; i++) {
             executorService.execute(() -> {
-                videoInfo.incrementViewCount();
-                videoInfoRepository.updateViewCount(categoryId, videoId, videoInfo.getViewCount());
+                reactionService.incrementViewCount(categoryId, videoId);
                 latch.countDown();
             });
         }
@@ -69,8 +70,7 @@ class VideoInfoConcurrencyTest {
 
         for(int i = 0; i < threadCount; i++) {
             executorService.execute(() -> {
-                videoInfo.incrementLikeCount();
-                videoInfoRepository.updateLikeCount(categoryId, videoId, videoInfo.getLikeCount());
+                reactionService.incrementLikeCount(categoryId, videoId);
                 latch.countDown();
             });
         }


### PR DESCRIPTION
### 🛠️ 작업 내용

---
- 조회수/좋아요수 동시성 제어 기능을 추가하였습니다. 테스트 코드 작성을 통해 정상적인 동작을 확인하였습니다.
### 💡 참고 사항

---
- 기존 ReactionService에 조회수/좋아요수를 증가시키는 메소드를 넣어두었습니다.
### 🚨 현재 버그

---

### ☑️ Git Close

---
- close #76 