### PR TITLE
토큰 관리

### DIFF
--- a/src/main/java/ojosama/talkak/auth/config/FilterConfig.java
+++ b/src/main/java/ojosama/talkak/auth/config/FilterConfig.java
@@ -23,7 +23,7 @@ public class FilterConfig {
     }
 
     @Bean
-    public JwtAuthorizationFilter jwtAuthorizationFilter(JwtUtil jwtUtil) {
-        return new JwtAuthorizationFilter(jwtUtil);
+    public JwtAuthorizationFilter jwtAuthorizationFilter(JwtUtil jwtUtil, ObjectMapper objectMapper) {
+        return new JwtAuthorizationFilter(jwtUtil, objectMapper);
     }
 }

--- a/src/main/java/ojosama/talkak/auth/config/FilterConfig.java
+++ b/src/main/java/ojosama/talkak/auth/config/FilterConfig.java
@@ -1,9 +1,11 @@
 package ojosama.talkak.auth.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import ojosama.talkak.auth.filter.AuthorizationCodeFilter;
 import ojosama.talkak.auth.filter.JwtAuthorizationFilter;
 import ojosama.talkak.auth.filter.SuccessHandler;
 import ojosama.talkak.auth.utils.JwtUtil;
+import ojosama.talkak.common.util.RedisUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,8 +13,13 @@ import org.springframework.context.annotation.Configuration;
 public class FilterConfig {
 
     @Bean
-    public SuccessHandler successHandler(JwtUtil jwtUtil, ObjectMapper objectMapper) {
-        return new SuccessHandler(jwtUtil, objectMapper);
+    public SuccessHandler successHandler(JwtUtil jwtUtil, RedisUtil redisUtil, ObjectMapper objectMapper, JwtProperties jwtProperties) {
+        return new SuccessHandler(jwtUtil, redisUtil, objectMapper, jwtProperties);
+    }
+
+    @Bean
+    public AuthorizationCodeFilter authorizationCodeFilter() {
+        return new AuthorizationCodeFilter();
     }
 
     @Bean

--- a/src/main/java/ojosama/talkak/auth/config/FilterConfig.java
+++ b/src/main/java/ojosama/talkak/auth/config/FilterConfig.java
@@ -23,7 +23,7 @@ public class FilterConfig {
     }
 
     @Bean
-    public JwtAuthorizationFilter jwtAuthorizationFilter(JwtUtil jwtUtil, RedisUtil redisUtil) {
-        return new JwtAuthorizationFilter(jwtUtil, redisUtil);
+    public JwtAuthorizationFilter jwtAuthorizationFilter(JwtUtil jwtUtil) {
+        return new JwtAuthorizationFilter(jwtUtil);
     }
 }

--- a/src/main/java/ojosama/talkak/auth/config/FilterConfig.java
+++ b/src/main/java/ojosama/talkak/auth/config/FilterConfig.java
@@ -23,7 +23,7 @@ public class FilterConfig {
     }
 
     @Bean
-    public JwtAuthorizationFilter jwtAuthorizationFilter(JwtUtil jwtUtil) {
-        return new JwtAuthorizationFilter(jwtUtil);
+    public JwtAuthorizationFilter jwtAuthorizationFilter(JwtUtil jwtUtil, RedisUtil redisUtil) {
+        return new JwtAuthorizationFilter(jwtUtil, redisUtil);
     }
 }

--- a/src/main/java/ojosama/talkak/auth/config/SecurityConfig.java
+++ b/src/main/java/ojosama/talkak/auth/config/SecurityConfig.java
@@ -3,7 +3,7 @@ package ojosama.talkak.auth.config;
 import lombok.RequiredArgsConstructor;
 import ojosama.talkak.auth.filter.JwtAuthorizationFilter;
 import ojosama.talkak.auth.filter.SuccessHandler;
-import ojosama.talkak.auth.service.AuthService;
+import ojosama.talkak.auth.service.OAuth2Service;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,7 +22,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final AuthService authService;
+    private final OAuth2Service OAuth2Service;
     private final SuccessHandler successHandler;
     private final JwtAuthorizationFilter jwtAuthorizationFilter;
     private final AuthProperties authProperties;
@@ -57,7 +57,7 @@ public class SecurityConfig {
                 .redirectionEndpoint(endpoint -> endpoint
                     .baseUri(authProperties.redirectionUri()))
                 .userInfoEndpoint(endpoint -> endpoint
-                    .userService(authService))
+                    .userService(OAuth2Service))
                 .successHandler(successHandler)
             )
             .addFilterBefore(jwtAuthorizationFilter, AuthorizationFilter.class)

--- a/src/main/java/ojosama/talkak/auth/config/SecurityConfig.java
+++ b/src/main/java/ojosama/talkak/auth/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
                     .requestMatchers("/h2-console/**").permitAll()
                     .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", swaggerAlias).permitAll()
                     .requestMatchers(authProperties.authorizationUri()).permitAll()
+                    .requestMatchers("/api/issue").permitAll()
                     .anyRequest().authenticated()
             )
             .oauth2Login((oauth2Login) -> oauth2Login

--- a/src/main/java/ojosama/talkak/auth/config/SecurityServiceConfig.java
+++ b/src/main/java/ojosama/talkak/auth/config/SecurityServiceConfig.java
@@ -1,6 +1,6 @@
 package ojosama.talkak.auth.config;
 
-import ojosama.talkak.auth.service.AuthService;
+import ojosama.talkak.auth.service.OAuth2Service;
 import ojosama.talkak.member.repository.MemberRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,7 +15,7 @@ public class SecurityServiceConfig {
     }
 
     @Bean
-    public AuthService authService(DefaultOAuth2UserService defaultOAuth2UserService, MemberRepository memberRepository) {
-        return new AuthService(defaultOAuth2UserService, memberRepository);
+    public OAuth2Service oAuth2Service(DefaultOAuth2UserService defaultOAuth2UserService, MemberRepository memberRepository) {
+        return new OAuth2Service(defaultOAuth2UserService, memberRepository);
     }
 }

--- a/src/main/java/ojosama/talkak/auth/controller/AuthApiController.java
+++ b/src/main/java/ojosama/talkak/auth/controller/AuthApiController.java
@@ -1,0 +1,25 @@
+package ojosama.talkak.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import ojosama.talkak.auth.dto.ReissueRequest;
+import ojosama.talkak.auth.dto.TokenResponse;
+import ojosama.talkak.common.exception.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+@Tag(name = "인증 API", description = "인증 관련 API를 담당합니다.")
+public interface AuthApiController {
+
+    @Operation(summary = "토큰 재발급", description = "토큰을 재발급 받습니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
+            @ApiResponse(responseCode = "A001", description = "유효하지 않은 access token입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "A002", description = "유효하지 않은 refresh token입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<TokenResponse> reissue(ReissueRequest request, Authentication authentication);
+}

--- a/src/main/java/ojosama/talkak/auth/controller/AuthApiController.java
+++ b/src/main/java/ojosama/talkak/auth/controller/AuthApiController.java
@@ -15,11 +15,17 @@ import org.springframework.security.core.Authentication;
 @Tag(name = "인증 API", description = "인증 관련 API를 담당합니다.")
 public interface AuthApiController {
 
-    @Operation(summary = "토큰 재발급", description = "토큰을 재발급 받습니다.")
+    @Operation(summary = "토큰 재발급", description = "토큰을 재발급받습니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
             @ApiResponse(responseCode = "A001", description = "유효하지 않은 access token입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "A002", description = "유효하지 않은 refresh token입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<TokenResponse> reissue(ReissueRequest request, Authentication authentication);
+
+    @Operation(summary = "토큰 발급", description = "테스트용 토큰을 발급받습니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "토큰 발급 성공"),
+    })
+    ResponseEntity<TokenResponse> issue();
 }

--- a/src/main/java/ojosama/talkak/auth/controller/AuthController.java
+++ b/src/main/java/ojosama/talkak/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import ojosama.talkak.auth.dto.TokenResponse;
 import ojosama.talkak.auth.service.AuthService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,5 +26,10 @@ public class AuthController implements AuthApiController {
         Long id = Long.valueOf(authentication.getPrincipal().toString());
         TokenResponse tokenResponse = authService.reissue(request.refreshToken(), id);
         return ResponseEntity.ok().body(tokenResponse);
+    }
+
+    @GetMapping("/issue")
+    public ResponseEntity<TokenResponse> issue() {
+        return ResponseEntity.ok(authService.issue());
     }
 }

--- a/src/main/java/ojosama/talkak/auth/controller/AuthController.java
+++ b/src/main/java/ojosama/talkak/auth/controller/AuthController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
-public class AuthController {
+public class AuthController implements AuthApiController {
 
     private final AuthService authService;
 

--- a/src/main/java/ojosama/talkak/auth/controller/AuthController.java
+++ b/src/main/java/ojosama/talkak/auth/controller/AuthController.java
@@ -1,0 +1,29 @@
+package ojosama.talkak.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import ojosama.talkak.auth.dto.ReissueRequest;
+import ojosama.talkak.auth.dto.TokenResponse;
+import ojosama.talkak.auth.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenResponse> reissue(@RequestBody ReissueRequest request,
+        Authentication authentication)
+    {
+        Long id = Long.valueOf(authentication.getPrincipal().toString());
+        TokenResponse tokenResponse = authService.reissue(request.refreshToken(), id);
+        return ResponseEntity.ok().body(tokenResponse);
+    }
+}

--- a/src/main/java/ojosama/talkak/auth/dto/ReissueRequest.java
+++ b/src/main/java/ojosama/talkak/auth/dto/ReissueRequest.java
@@ -1,0 +1,5 @@
+package ojosama.talkak.auth.dto;
+
+public record ReissueRequest(
+    String refreshToken
+) {}

--- a/src/main/java/ojosama/talkak/auth/dto/ReissueRequest.java
+++ b/src/main/java/ojosama/talkak/auth/dto/ReissueRequest.java
@@ -1,5 +1,9 @@
 package ojosama.talkak.auth.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.LowerCamelCaseStrategy.class)
 public record ReissueRequest(
     String refreshToken
 ) {}

--- a/src/main/java/ojosama/talkak/auth/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/ojosama/talkak/auth/filter/JwtAuthorizationFilter.java
@@ -29,6 +29,11 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     {
         String headerValue = request.getHeader("Authorization");
 
+        if (headerValue == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         if (isValidToken(headerValue)) {
             SecurityContextHolder.getContext()
                 .setAuthentication(

--- a/src/main/java/ojosama/talkak/auth/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/ojosama/talkak/auth/filter/JwtAuthorizationFilter.java
@@ -27,10 +27,16 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         if (isValidToken(headerValue)) {
             SecurityContextHolder.getContext()
                 .setAuthentication(
-                    createUsernamePasswordAuthenticationToken(headerValue.split(" ")[1]));
+                    createUsernamePasswordAuthenticationToken(resolveToken(headerValue)));
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private boolean isValidToken(String value) {
+        return !Objects.isNull(value) &&
+            value.startsWith("Bearer ") &&
+            jwtUtil.isValidToken(value.split(" ")[1]);
     }
 
     private UsernamePasswordAuthenticationToken createUsernamePasswordAuthenticationToken(String token) {
@@ -38,9 +44,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         return new UsernamePasswordAuthenticationToken(id, null, new ArrayList<>());
     }
 
-    private boolean isValidToken(String value) {
-        return !Objects.isNull(value) &&
-            value.startsWith("Bearer ") &&
-            jwtUtil.isValidToken(value.split(" ")[1]);
+    private String resolveToken(String headerValue) {
+        return headerValue.split(" ")[1].trim();
     }
 }

--- a/src/main/java/ojosama/talkak/auth/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/ojosama/talkak/auth/filter/JwtAuthorizationFilter.java
@@ -1,16 +1,21 @@
 package ojosama.talkak.auth.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import ojosama.talkak.auth.utils.JwtUtil;
-import ojosama.talkak.common.exception.TalKakException;
+import ojosama.talkak.common.exception.ErrorResponse;
 import ojosama.talkak.common.exception.code.AuthError;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -19,12 +24,13 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
         FilterChain filterChain) throws ServletException, IOException
     {
-        String headerValue = request.getHeader("Authorization");
+        String headerValue = request.getHeader(HttpHeaders.AUTHORIZATION);
 
         if (headerValue == null) {
             filterChain.doFilter(request, response);
@@ -38,7 +44,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
             return;
         }
-        throw TalKakException.of(AuthError.INVALID_ACCESS_TOKEN);
+        handleInvalidAccessTokenException(response);
     }
 
     private boolean isValidToken(String value) {
@@ -58,5 +64,16 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private String resolveToken(String headerValue) {
         return headerValue.split(" ")[1].trim();
+    }
+
+    private void handleInvalidAccessTokenException(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        AuthError error = AuthError.INVALID_ACCESS_TOKEN;
+        response.getWriter()
+            .write(objectMapper.writeValueAsString(
+                ErrorResponse.of(error.status(), error.code(), error.message())));
     }
 }

--- a/src/main/java/ojosama/talkak/auth/filter/SuccessHandler.java
+++ b/src/main/java/ojosama/talkak/auth/filter/SuccessHandler.java
@@ -5,10 +5,13 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import ojosama.talkak.auth.config.JwtProperties;
 import ojosama.talkak.auth.dto.OAuth2UserDetails;
 import ojosama.talkak.auth.dto.TokenResponse;
 import ojosama.talkak.auth.utils.JwtUtil;
+import ojosama.talkak.common.util.RedisUtil;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 
@@ -16,7 +19,9 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 public class SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtUtil jwtUtil;
+    private final RedisUtil redisUtil;
     private final ObjectMapper objectMapper;
+    private final JwtProperties jwtProperties;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -24,7 +29,11 @@ public class SuccessHandler implements AuthenticationSuccessHandler {
 
         OAuth2UserDetails oAuth2User = (OAuth2UserDetails) authentication.getPrincipal();
         String accessToken = jwtUtil.generateAccessToken(oAuth2User.id(), oAuth2User.email(), oAuth2User.username());
-        String refreshToken = jwtUtil.generateRefreshToken(oAuth2User.id(), oAuth2User.email(), oAuth2User.username());
+        String refreshToken = jwtUtil.generateRefreshToken();
+
+        String key = String.format("REFRESH_TOKEN:%d", oAuth2User.id());
+        Duration duration = Duration.ofSeconds(jwtProperties.refreshTokenExpireIn());
+        redisUtil.setValues(key, refreshToken, duration);
 
         response.setContentType("application/json");
         response.setCharacterEncoding("utf-8");

--- a/src/main/java/ojosama/talkak/auth/filter/SuccessHandler.java
+++ b/src/main/java/ojosama/talkak/auth/filter/SuccessHandler.java
@@ -11,6 +11,7 @@ import ojosama.talkak.auth.config.JwtProperties;
 import ojosama.talkak.auth.dto.OAuth2UserDetails;
 import ojosama.talkak.auth.dto.TokenResponse;
 import ojosama.talkak.auth.utils.JwtUtil;
+import ojosama.talkak.common.util.RedisKeyUtil;
 import ojosama.talkak.common.util.RedisUtil;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -31,7 +32,7 @@ public class SuccessHandler implements AuthenticationSuccessHandler {
         String accessToken = jwtUtil.generateAccessToken(oAuth2User.id(), oAuth2User.email(), oAuth2User.username());
         String refreshToken = jwtUtil.generateRefreshToken();
 
-        String key = String.format("REFRESH_TOKEN:%d", oAuth2User.id());
+        String key = RedisKeyUtil.REFRESH_TOKEN.of(oAuth2User.id());
         Duration duration = Duration.ofSeconds(jwtProperties.refreshTokenExpireIn());
         redisUtil.setValues(key, refreshToken, duration);
 

--- a/src/main/java/ojosama/talkak/auth/service/AuthService.java
+++ b/src/main/java/ojosama/talkak/auth/service/AuthService.java
@@ -39,6 +39,13 @@ public class AuthService {
         return TokenResponse.of(accessToken, refreshToken);
     }
 
+    public TokenResponse issue() {
+        Member member = memberRepository.save(Member.of("test", "", "test@test.com"));
+        String accessToken = jwtUtil.generateAccessToken(member.getId(), member.getEmail(), member.getUsername());
+        String refreshToken = jwtUtil.generateRefreshToken();
+        return TokenResponse.of(accessToken, refreshToken);
+    }
+
     private Member findMemberById(Long id) {
         return memberRepository.findById(id)
             .orElseThrow(() -> TalKakException.of(MemberError.NOT_EXISTING_MEMBER));

--- a/src/main/java/ojosama/talkak/auth/service/AuthService.java
+++ b/src/main/java/ojosama/talkak/auth/service/AuthService.java
@@ -1,32 +1,45 @@
 package ojosama.talkak.auth.service;
 
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
-import ojosama.talkak.auth.dto.GoogleUserDetails;
-import ojosama.talkak.auth.dto.OAuth2UserDetails;
+import ojosama.talkak.auth.config.JwtProperties;
+import ojosama.talkak.auth.dto.TokenResponse;
+import ojosama.talkak.auth.utils.JwtUtil;
+import ojosama.talkak.common.exception.TalKakException;
+import ojosama.talkak.common.exception.code.AuthError;
+import ojosama.talkak.common.exception.code.MemberError;
+import ojosama.talkak.common.util.RedisUtil;
 import ojosama.talkak.member.domain.Member;
 import ojosama.talkak.member.repository.MemberRepository;
-import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
-import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
-import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
 
+@Service
 @RequiredArgsConstructor
-public class AuthService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+public class AuthService {
 
-    private final DefaultOAuth2UserService defaultOAuth2UserService;
+    private final JwtUtil jwtUtil;
+    private final RedisUtil redisUtil;
     private final MemberRepository memberRepository;
+    private final JwtProperties jwtProperties;
 
-    @Override
-    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        OAuth2User oAuth2User = defaultOAuth2UserService.loadUser(userRequest);
-        GoogleUserDetails userDetails = GoogleUserDetails.from(oAuth2User.getAttributes());
+    public TokenResponse reissue(String refreshToken, Long id) {
+        if (!jwtUtil.isValidToken(refreshToken)) {
+            throw TalKakException.of(AuthError.INVALID_REFRESH_TOKEN);
+        }
+        Member member = findMemberById(id);
 
-        return OAuth2UserDetails.of(memberRepository.findByEmail(userDetails.email())
-            .orElse(register(userDetails)));
+        String accessToken = jwtUtil.generateAccessToken(id, member.getEmail(), member.getUsername());
+        refreshToken = jwtUtil.generateRefreshToken();
+
+        String key = String.format("REFRESH_TOKEN:%d", id);
+        Duration duration = Duration.ofSeconds(jwtProperties.refreshTokenExpireIn());
+        redisUtil.setValues(key, refreshToken, duration);
+
+        return TokenResponse.of(accessToken, refreshToken);
     }
 
-    private Member register(GoogleUserDetails userDetails) {
-        return memberRepository.save(userDetails.toEntity());
+    private Member findMemberById(Long id) {
+        return memberRepository.findById(id)
+            .orElseThrow(() -> TalKakException.of(MemberError.NOT_EXISTING_MEMBER));
     }
 }

--- a/src/main/java/ojosama/talkak/auth/service/AuthService.java
+++ b/src/main/java/ojosama/talkak/auth/service/AuthService.java
@@ -8,6 +8,7 @@ import ojosama.talkak.auth.utils.JwtUtil;
 import ojosama.talkak.common.exception.TalKakException;
 import ojosama.talkak.common.exception.code.AuthError;
 import ojosama.talkak.common.exception.code.MemberError;
+import ojosama.talkak.common.util.RedisKeyUtil;
 import ojosama.talkak.common.util.RedisUtil;
 import ojosama.talkak.member.domain.Member;
 import ojosama.talkak.member.repository.MemberRepository;
@@ -31,7 +32,7 @@ public class AuthService {
         String accessToken = jwtUtil.generateAccessToken(id, member.getEmail(), member.getUsername());
         refreshToken = jwtUtil.generateRefreshToken();
 
-        String key = String.format("REFRESH_TOKEN:%d", id);
+        String key = RedisKeyUtil.REFRESH_TOKEN.of(id);
         Duration duration = Duration.ofSeconds(jwtProperties.refreshTokenExpireIn());
         redisUtil.setValues(key, refreshToken, duration);
 

--- a/src/main/java/ojosama/talkak/auth/service/OAuth2Service.java
+++ b/src/main/java/ojosama/talkak/auth/service/OAuth2Service.java
@@ -1,0 +1,32 @@
+package ojosama.talkak.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import ojosama.talkak.auth.dto.GoogleUserDetails;
+import ojosama.talkak.auth.dto.OAuth2UserDetails;
+import ojosama.talkak.member.domain.Member;
+import ojosama.talkak.member.repository.MemberRepository;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@RequiredArgsConstructor
+public class OAuth2Service implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final DefaultOAuth2UserService defaultOAuth2UserService;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = defaultOAuth2UserService.loadUser(userRequest);
+        GoogleUserDetails userDetails = GoogleUserDetails.from(oAuth2User.getAttributes());
+
+        return OAuth2UserDetails.of(memberRepository.findByEmail(userDetails.email())
+            .orElse(register(userDetails)));
+    }
+
+    private Member register(GoogleUserDetails userDetails) {
+        return memberRepository.save(userDetails.toEntity());
+    }
+}

--- a/src/main/java/ojosama/talkak/auth/utils/JwtUtil.java
+++ b/src/main/java/ojosama/talkak/auth/utils/JwtUtil.java
@@ -20,11 +20,24 @@ public class JwtUtil {
     }
 
     public String generateAccessToken(Long id, String email, String username) {
-        return generateToken(id, email, username, accessTokenExpireIn);
+        long current = System.currentTimeMillis();
+        return Jwts.builder()
+            .subject(id.toString())
+            .claim("email", email)
+            .claim("username", username)
+            .issuedAt(new Date(current))
+            .expiration(new Date(current + accessTokenExpireIn))
+            .signWith(secretKey)
+            .compact();
     }
 
-    public String generateRefreshToken(Long id, String email, String username) {
-        return generateToken(id, email, username, refreshTokenExpireIn);
+    public String generateRefreshToken() {
+        long current = System.currentTimeMillis();
+        return Jwts.builder()
+            .issuedAt(new Date(current))
+            .expiration(new Date(current + refreshTokenExpireIn))
+            .signWith(secretKey)
+            .compact();
     }
 
     public boolean isValidToken(String token) {
@@ -46,17 +59,5 @@ public class JwtUtil {
             .parseSignedClaims(token)
             .getPayload()
             .getSubject());
-    }
-
-    private String generateToken(Long id, String email, String username, Long expiration) {
-        long current = System.currentTimeMillis();
-        return Jwts.builder()
-            .subject(id.toString())
-            .claim("email", email)
-            .claim("username", username)
-            .issuedAt(new Date(current))
-            .expiration(new Date(current + expiration))
-            .signWith(secretKey)
-            .compact();
     }
 }

--- a/src/main/java/ojosama/talkak/common/exception/code/AuthError.java
+++ b/src/main/java/ojosama/talkak/common/exception/code/AuthError.java
@@ -1,0 +1,31 @@
+package ojosama.talkak.common.exception.code;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum AuthError implements ErrorCode {
+
+    /* 401 Unauthorized */
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 access token입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 refresh token입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return status;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/ojosama/talkak/common/util/RedisKeyUtil.java
+++ b/src/main/java/ojosama/talkak/common/util/RedisKeyUtil.java
@@ -1,0 +1,16 @@
+package ojosama.talkak.common.util;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RedisKeyUtil {
+    REFRESH_TOKEN("refresh_token:%d");
+
+    private final String format;
+
+    public String of(Long id) {
+        return String.format(format, id);
+    }
+}

--- a/src/main/java/ojosama/talkak/member/domain/Member.java
+++ b/src/main/java/ojosama/talkak/member/domain/Member.java
@@ -17,7 +17,6 @@ import ojosama.talkak.comment.domain.Comment;
 import ojosama.talkak.common.entity.BaseEntity;
 import ojosama.talkak.common.exception.TalKakException;
 import ojosama.talkak.common.exception.code.MemberError;
-import ojosama.talkak.video.domain.Video;
 
 @Entity
 @Table(name = "member")
@@ -30,9 +29,9 @@ public class Member extends BaseEntity {
     private String imageUrl;
     @Column(unique = true)
     private String email;
-    private Boolean gender;
+    private Boolean gender = true;
     @Enumerated(EnumType.STRING)
-    private Age age;
+    private Age age = Age.TEN;
     @Enumerated(EnumType.STRING)
     private MembershipTier membership = MembershipTier.Basic;
     private Integer point = 0;


### PR DESCRIPTION
### 🛠️ 작업 내용

- 로그인 시 redis에 refresh token 저장
- 인증이 필요한 요청에서 액세스 토큰이 만료되었을 경우 에러 응답
- 토큰 재발급 API 구현

---

### 💡 참고 사항

- 테스트용 토큰 발급 API도 구현해두었습니다.
- Member 성별(`남자`), 나이(`10대`) 기본값 설정해두었습니다.
- redis key 관련 로직들을 하나로 모으면 좋을 것 같아 우선 common 패키지에 `RedisKeyUtil`이라는 enum을 만들어 두었는데, 이에 대해 의견 주시면 감사하겠습니다.

---

### 🚨 현재 버그

---

### ☑️ Git Close

close #92 

---