### PR TITLE
redis 연결 오류 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ out/
 !**/src/main/**/out/
 !**/src/test/**/out/
 src/main/resources/*.properties
+src/test/resources/*.properties
 src/main/resources/*.yaml
 src/main/resources/*.yml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ VOLUME /tmp
 
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} /app/app.jar
+ENV SPRING_PROFILES_ACTIVE=prod
 
 EXPOSE 8080
 

--- a/src/main/java/ojosama/talkak/common/config/DemoDataInitializer.java
+++ b/src/main/java/ojosama/talkak/common/config/DemoDataInitializer.java
@@ -92,9 +92,6 @@ public class DemoDataInitializer {
                 // Redis에 VideoInfo 저장
                 VideoInfo videoInfo = VideoInfo.of(video.getCreatedAt(), video.getViews(),
                     video.getCountLikes());
-//                String key = VideoKey.VIDEO_INFO.generateKey(category.getId(),
-//                    video.getId());
-//                redisUtil.setHashOps(key, hashConverter.toMap(videoInfo));
                 videoInfoRepository.save(category.getId(), video.getId(), videoInfo);
 
                 // 썸네일 인덱스 증가 (순환)

--- a/src/main/java/ojosama/talkak/common/config/DemoDataInitializer.java
+++ b/src/main/java/ojosama/talkak/common/config/DemoDataInitializer.java
@@ -21,7 +21,7 @@ import ojosama.talkak.video.repository.VideoRepository;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-@Profile("local")
+//@Profile("local")
 @Component
 public class DemoDataInitializer {
     private final MemberRepository memberRepository;
@@ -92,9 +92,9 @@ public class DemoDataInitializer {
                 // Redis에 VideoInfo 저장
                 VideoInfo videoInfo = VideoInfo.of(video.getCreatedAt(), video.getViews(),
                     video.getCountLikes());
-                String key = VideoKey.VIDEO_INFO.generateKey(category.getId(),
-                    video.getId());
-                redisUtil.setHashOps(key, hashConverter.toMap(videoInfo));
+//                String key = VideoKey.VIDEO_INFO.generateKey(category.getId(),
+//                    video.getId());
+//                redisUtil.setHashOps(key, hashConverter.toMap(videoInfo));
                 videoInfoRepository.save(category.getId(), video.getId(), videoInfo);
 
                 // 썸네일 인덱스 증가 (순환)

--- a/src/main/java/ojosama/talkak/common/config/RedisConfig.java
+++ b/src/main/java/ojosama/talkak/common/config/RedisConfig.java
@@ -3,6 +3,7 @@ package ojosama.talkak.common.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import ojosama.talkak.common.util.HashConverter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -17,11 +18,14 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Slf4j
 public class RedisConfig {
 
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        String host = System.getProperty("spring.redis.host", "localhost");
-        int port = Integer.parseInt(System.getProperty("spring.redis.port", "6379"));
-
         log.info("Connecting to Redis at " + host + ":" + port);
 
         return new LettuceConnectionFactory(host, port);

--- a/src/test/java/ojosama/talkak/redis/config/RedisTestContainerConfig.java
+++ b/src/test/java/ojosama/talkak/redis/config/RedisTestContainerConfig.java
@@ -29,8 +29,8 @@ public class RedisTestContainerConfig implements BeforeAllCallback {
         Integer mappedPort = redisContainer.getMappedPort(REDIS_PORT);
 
         // System Properties 설정
-        System.setProperty("spring.redis.host", host);
-        System.setProperty("spring.redis.port", mappedPort.toString());
+        System.setProperty("spring.data.redis.host", host);
+        System.setProperty("spring.data.redis.port", mappedPort.toString());
 
         log.debug("Redis TestContainer started at {}:{}", host, mappedPort);
     }
@@ -39,8 +39,8 @@ public class RedisTestContainerConfig implements BeforeAllCallback {
     @Override
     public void beforeAll(ExtensionContext context) {
         // 시스템 프로퍼티 설정 확인
-        String host = System.getProperty("spring.redis.host");
-        String port = System.getProperty("spring.redis.port");
+        String host = System.getProperty("spring.data.redis.host");
+        String port = System.getProperty("spring.data.redis.port");
         log.debug("Verified Redis properties - Host: {}, Port: {}", host, port);
     }
 

--- a/src/test/java/ojosama/talkak/redis/service/RecommendationServiceTest.java
+++ b/src/test/java/ojosama/talkak/redis/service/RecommendationServiceTest.java
@@ -1,7 +1,6 @@
 package ojosama.talkak.redis.service;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -27,10 +26,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @Slf4j
 @ExtendWith({RedisTestContainerConfig.class, RecommendTestContainerConfig.class})
+@ActiveProfiles("test")
 class RecommendationServiceTest {
 
     @Autowired


### PR DESCRIPTION
### 🛠️ 작업 내용

---
- 도커 컨테이너에서 스프링 서버 초기 실행 시 redis 컨테이너와 연결하지 못하는 에러를 해결하였습니다.
- 프로퍼티에서 redis의 host,port를 제대로 받아오지 못하는 오류가 있었던 것 같습니다.
### 💡 참고 사항

---
- 오류를 해결하는 과정에서 도커 프로퍼티 프로필을 prod(배포 프로필)로 변경하였는데, 현재 Initializer의 작동 프로필이 local로 설정되어 있어 ec2에서 데모 데이터가 생성되지 않을 것 같아 일단 @Profiles를 주석처리 하였습니다. 나중에 완전한 배포 환경을 구성할때 다시 활성화할 생각입니다.
- DemoDataInitializer의 95~97번째 줄(주석 처리된 부분)이 98번째 줄과 동일한 역할을 중복 수행하는 것 같아 일단 주석 처리 하였는데 맞는지 궁금합니다. (영진님 답변해주시면 감사하겠습니다.)
### 🚨 현재 버그

---
- 프로퍼티 파일들이 일부 수정되서, 혹시 로컬 환경에서 스프링 부트 서버 실행이 실패하시는 분 계시면 제가 프로퍼티 파일을 공유해드리겠습니다.
### ☑️ Git Close

---