### PR TITLE
영상 불러오기 인증 필터 미적용 및 파라미터 타입 오류 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 	testImplementation "org.testcontainers:testcontainers:1.19.0"
 	testImplementation "org.testcontainers:junit-jupiter:1.19.0"
 	testImplementation 'org.awaitility:awaitility:4.2.0'  // 비동기 대기를 위한 라이브러리
+	testImplementation 'org.apache.commons:commons-collections4:4.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/ojosama/talkak/auth/config/SecurityConfig.java
+++ b/src/main/java/ojosama/talkak/auth/config/SecurityConfig.java
@@ -59,7 +59,8 @@ public class SecurityConfig {
                     .requestMatchers("/h2-console/**").permitAll()
                     .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", swaggerAlias).permitAll()
                     .requestMatchers(authProperties.authorizationUri()).permitAll()
-                    .requestMatchers("/api/issue").permitAll()
+                    .requestMatchers("/api/issue", "/api/videos",
+                        "/api/videos/{videoId:\\d+}","/api/videos/youtube/**").permitAll()
                     .anyRequest().authenticated()
             )
             .oauth2Login((oauth2Login) -> oauth2Login

--- a/src/main/java/ojosama/talkak/common/util/LocalDateTimeSerializer.java
+++ b/src/main/java/ojosama/talkak/common/util/LocalDateTimeSerializer.java
@@ -1,0 +1,26 @@
+package ojosama.talkak.common.util;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateTimeSerializer extends StdSerializer<LocalDateTime> {
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    public LocalDateTimeSerializer() {
+        this(null);
+    }
+
+    public LocalDateTimeSerializer(Class<LocalDateTime> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(LocalDateTime localDateTime, JsonGenerator jsonGenerator,
+        SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeString(localDateTime.format(formatter));
+    }
+}

--- a/src/main/java/ojosama/talkak/video/controller/VideoApiController.java
+++ b/src/main/java/ojosama/talkak/video/controller/VideoApiController.java
@@ -42,7 +42,7 @@ import org.springframework.web.bind.annotation.RequestParam;
         @ApiResponse(responseCode = "C001", description = "존재하지 않는 카테고리입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<List<YoutubeApiResponse>> getPopularYoutubeShortsByCategory(
-        YoutubeCategoryRequest youtubeCategoryRequest) throws IOException;
+        @PathVariable Long categoryId) throws IOException;
 
     @Operation(summary = "특정 영상 불러오기", description = "특정 영상에 대한 자세한 정보 불러오기")
     @ApiResponses(value = {
@@ -59,7 +59,7 @@ import org.springframework.web.bind.annotation.RequestParam;
         @ApiResponse(responseCode = "V004", description = "존재하지 않는 비디오",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<List<VideoInfoResponse>> getPopularVideosByCategory(@RequestBody VideoCategoryRequest req,
+    public ResponseEntity<List<VideoInfoResponse>> getPopularVideosByCategory(@RequestParam("categoryId") Long categoryId,
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "5") int size);
 }

--- a/src/main/java/ojosama/talkak/video/controller/VideoController.java
+++ b/src/main/java/ojosama/talkak/video/controller/VideoController.java
@@ -50,11 +50,11 @@ public class VideoController implements VideoApiController {
     }
 
     @GetMapping
-    public ResponseEntity<List<VideoInfoResponse>> getPopularVideosByCategory(@RequestBody VideoCategoryRequest req,
+    public ResponseEntity<List<VideoInfoResponse>> getPopularVideosByCategory(@RequestParam("categoryId") Long categoryId,
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "5") int size) {
         Pageable pageable = PageRequest.of(page, size);
-        List<VideoInfoResponse> videos = videoService.getVideoByCategory(req, pageable);
+        List<VideoInfoResponse> videos = videoService.getVideoByCategory(new VideoCategoryRequest(categoryId), pageable);
         return ResponseEntity.ok(videos);
     }
 
@@ -99,11 +99,10 @@ public class VideoController implements VideoApiController {
     // 메인페이지에서 유튜브 관련 영상 불러오기(카테고리 지정)
     @GetMapping("/youtube/{categoryId}")
     public ResponseEntity<List<YoutubeApiResponse>> getPopularYoutubeShortsByCategory(
-            @PathVariable("categoryId")
-            YoutubeCategoryRequest youtubeCategoryRequest) throws IOException {
+            @PathVariable Long categoryId) throws IOException {
         long start = System.currentTimeMillis();
         List<YoutubeApiResponse> response = youtubeService.getShortsByCategory(
-                youtubeCategoryRequest);
+                new YoutubeCategoryRequest(categoryId));
         long end = System.currentTimeMillis();
         log.info("카테고리별 쇼츠 Cache 수행시간 : " + (end - start));
 

--- a/src/main/java/ojosama/talkak/video/response/VideoInfoResponse.java
+++ b/src/main/java/ojosama/talkak/video/response/VideoInfoResponse.java
@@ -1,12 +1,15 @@
 package ojosama.talkak.video.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.time.LocalDateTime;
+import ojosama.talkak.common.util.LocalDateTimeSerializer;
 
 public record VideoInfoResponse(
     Long videoId,
     String thumbnail,
     String title,
     Long memberId,
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
     LocalDateTime createdAt
     ) {
 


### PR DESCRIPTION
### 🛠️ 작업 내용

---
- 유튜브/일반 영상 불러오기에 인증 필터가 적용되지 않도록 설정하였습니다.
- 추가로 영상 불러오기 관련한 2개의 API에 categoryId를 받아오는 과정에서 오류가 발생하여 해당 값을 body값이 아닌 쿼리 파라미터 값으로 받도록 수정하였습니다.
- /videos API에서 LocalDateTime을 직렬화하지 못하는 오류가 발생해서 record 응답 객체에 별도로 직렬화를 수행할 수 있는 커스텀 직렬화 클래스를 만들었습니다. 원래도 이런 오류가 발생했었나 모르겠네요..
### 💡 참고 사항

---
- 인증이 필요한 video/extract랑 video/upload API가 있어서 매칭 패턴을 videos/**로 설정하지 못해 살짝 지저분해진 점이 있습니다..
### 🚨 현재 버그

---

### ☑️ Git Close

---