### PR TITLE
썸네일 이미지 처리

### DIFF
--- a/src/main/java/ojosama/talkak/video/controller/VideoController.java
+++ b/src/main/java/ojosama/talkak/video/controller/VideoController.java
@@ -81,9 +81,9 @@ public class VideoController implements VideoApiController {
     }
 
     @PostMapping("/highlight-selection")
-    public ResponseEntity<VideoResponse> selectHighlight(@RequestBody HighlightRequest req) {
+    public ResponseEntity<VideoInfoResponse> selectHighlight(@RequestBody HighlightRequest req) {
         String uniqueFileName = awsS3Service.deleteFilesExceptIndex(req.index(), req.s3Url());
-        VideoResponse response = videoService.createSelectedHighlight(req, uniqueFileName);
+        VideoInfoResponse response = videoService.createSelectedHighlight(req, uniqueFileName);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/ojosama/talkak/video/domain/Video.java
+++ b/src/main/java/ojosama/talkak/video/domain/Video.java
@@ -42,6 +42,13 @@ public class Video extends BaseEntity {
         this.countLikes = countLikes;
     }
 
+    public Video(String title, Long memberId, Long categoryId, String thumbnail, String uniqueFileName) {
+        this.title = title;
+        this.memberId = memberId;
+        this.categoryId = categoryId;
+        this.thumbnail = thumbnail;
+        this.uniqueFileName = uniqueFileName;
+    }
     public Video(String title, Long memberId, Long categoryId, String uniqueFileName) {
         this.title = title;
         this.memberId = memberId;

--- a/src/main/java/ojosama/talkak/video/service/AwsS3Service.java
+++ b/src/main/java/ojosama/talkak/video/service/AwsS3Service.java
@@ -77,7 +77,9 @@ public class AwsS3Service {
         for (int i = 0; i < 5; i++) {
             if (i != index) {
                 String key = String.format("%s_%d.mp4", fileName, i);
+                String thumbnailKey = String.format("thumbnails/%s_%d.jpg", fileName, i);
                 amazonS3.deleteObject(bucket, key);
+                amazonS3.deleteObject(bucket, thumbnailKey);
             }
         }
         return String.format("%s_%d.mp4", fileName, index);

--- a/src/main/java/ojosama/talkak/video/service/AwsS3Service.java
+++ b/src/main/java/ojosama/talkak/video/service/AwsS3Service.java
@@ -28,6 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class AwsS3Service {
 
+    private final static String thumbnailPath = "src/main/resources/thumbnails/";
     private final AmazonS3 amazonS3;
     private final VideoRepository videoRepository;
 
@@ -45,7 +46,7 @@ public class AwsS3Service {
             amazonS3.putObject(new PutObjectRequest(bucket, fileName, file.getInputStream(), null));
 
             String thumbnailFilePath = ThumbnailExtractor.extract(file,
-                fileName.replace(".mp4", ""));
+                thumbnailPath + fileName.replace(".mp4", ""));
             if (thumbnailFilePath == null) {
                 throw new IOException("Failed to extract thumbnail");
             }

--- a/src/main/java/ojosama/talkak/video/service/VideoService.java
+++ b/src/main/java/ojosama/talkak/video/service/VideoService.java
@@ -1,34 +1,33 @@
 package ojosama.talkak.video.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import ojosama.talkak.common.exception.TalKakException;
 import ojosama.talkak.common.exception.code.MemberError;
 import ojosama.talkak.common.exception.code.VideoError;
+import ojosama.talkak.common.util.WebClientUtil;
 import ojosama.talkak.member.domain.Member;
 import ojosama.talkak.member.repository.MemberRepository;
+import ojosama.talkak.reaction.service.ReactionService;
 import ojosama.talkak.recommendation.domain.VideoInfo;
 import ojosama.talkak.recommendation.repository.VideoInfoRepository;
-import ojosama.talkak.reaction.service.ReactionService;
 import ojosama.talkak.video.domain.Video;
 import ojosama.talkak.video.repository.VideoRepository;
 import ojosama.talkak.video.request.HighlightRequest;
 import ojosama.talkak.video.request.PythonDto;
 import ojosama.talkak.video.request.VideoCategoryRequest;
+import ojosama.talkak.video.request.YoutubeUrlValidationRequest;
 import ojosama.talkak.video.response.MemberInfoResponse;
 import ojosama.talkak.video.response.VideoDetailsResponse;
 import ojosama.talkak.video.response.VideoInfoResponse;
-import ojosama.talkak.video.response.VideoResponse;
 import ojosama.talkak.video.response.YoutubeUrlValidationAPIResponse;
-import ojosama.talkak.video.request.YoutubeUrlValidationRequest;
 import ojosama.talkak.video.response.YoutubeUrlValidationResponse;
 import ojosama.talkak.video.util.IdExtractor;
-import ojosama.talkak.common.util.WebClientUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import java.util.Optional;
 
 @Service
 public class VideoService {
@@ -37,6 +36,10 @@ public class VideoService {
     private String YOUTUBE_API_KEY;
     @Value("${youtube.api-url}")
     private String YOUTUBE_API_BASE_URL;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+    @Value("${cloud.aws.region.static}")
+    private String region;
 
     private final WebClientUtil webClientUtil;
     private final VideoRepository videoRepository;
@@ -86,12 +89,15 @@ public class VideoService {
             .collect(Collectors.toList());
     }
 
-    public VideoResponse createSelectedHighlight(HighlightRequest req, String uniqueFileName) {
+    public VideoInfoResponse createSelectedHighlight(HighlightRequest req, String uniqueFileName) {
         PythonDto pythonDto = req.pythonDto();
+        String key = "thumbnails/" + uniqueFileName + ".jpg";
+        String thumbnail = String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
         Video video = videoRepository.save(
-            new Video(pythonDto.title(), pythonDto.memberId(), pythonDto.categoryId(), uniqueFileName));
-        return new VideoResponse(video.getId(), video.getTitle(), video.getMemberId(),
-            video.getCategoryId(), video.getUniqueFileName());
+            new Video(pythonDto.title(), pythonDto.memberId(), pythonDto.categoryId(), thumbnail,
+                uniqueFileName));
+        return new VideoInfoResponse(video.getId(), video.getThumbnail(), video.getTitle(),
+            video.getMemberId(), video.getCreatedAt());
     }
 
     public YoutubeUrlValidationResponse validateYoutubeUrl(YoutubeUrlValidationRequest req) {


### PR DESCRIPTION
### 🛠️ 작업 내용

- ThumbnailExtractor 를 사용하여 S3에 하이라이트 영상들을 업로드할 때 썸네일 이미지도 같이 업로드 되도록 하였습니다. 이때 해당 썸네일 이미지의 키값은 `"thumbnails/" + 이미지 파일이름` 입니다.
- 그리고 하이라이트 영상을 선택하면서 s3에 업로드된 5개 영상 중 선택되지 않은 4개의 영상들을 삭제하는 로직에 썸네일 이미지도 동일하게 수행하도록 구현했습니다.

### 💡 참고 사항

---

### 🚨 현재 버그

---

### ☑️ Git Close

---