### PR TITLE
인증 skip 엔드포인트 jwt 필터에 적용되지 않도록 수정

### DIFF
--- a/src/main/java/ojosama/talkak/auth/config/FilterConfig.java
+++ b/src/main/java/ojosama/talkak/auth/config/FilterConfig.java
@@ -1,16 +1,26 @@
 package ojosama.talkak.auth.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import ojosama.talkak.auth.filter.AuthorizationCodeFilter;
 import ojosama.talkak.auth.filter.JwtAuthorizationFilter;
 import ojosama.talkak.auth.filter.SuccessHandler;
 import ojosama.talkak.auth.utils.JwtUtil;
 import ojosama.talkak.common.util.RedisUtil;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
 public class FilterConfig {
+
+    private final AuthProperties authProperties;
+
+    @Value("${springdoc.swagger-ui.path}")
+    private String swaggerAlias;
 
     @Bean
     public SuccessHandler successHandler(JwtUtil jwtUtil, RedisUtil redisUtil, ObjectMapper objectMapper, JwtProperties jwtProperties) {
@@ -23,7 +33,22 @@ public class FilterConfig {
     }
 
     @Bean
-    public JwtAuthorizationFilter jwtAuthorizationFilter(JwtUtil jwtUtil, ObjectMapper objectMapper) {
-        return new JwtAuthorizationFilter(jwtUtil, objectMapper);
+    public JwtAuthorizationFilter jwtAuthorizationFilter(JwtUtil jwtUtil, ObjectMapper objectMapper, List<String> skipPaths) {
+        return new JwtAuthorizationFilter(jwtUtil, objectMapper, skipPaths);
+    }
+
+    @Bean
+    public List<String> skipPaths() {
+        return Arrays.asList(
+            "/h2-console/**",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            swaggerAlias,
+            authProperties.authorizationUri(),
+            "/api/issue",
+            "/api/videos",
+            "/api/videos/{videoId:\\d+}",
+            "/api/videos/youtube/**"
+        );
     }
 }

--- a/src/main/java/ojosama/talkak/auth/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/ojosama/talkak/auth/filter/JwtAuthorizationFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import ojosama.talkak.auth.utils.JwtUtil;
@@ -25,6 +26,13 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
     private final ObjectMapper objectMapper;
+    private final List<String> skipPaths;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+        return skipPaths.stream().anyMatch(path::startsWith);
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,


### PR DESCRIPTION
### 🛠️ 작업 내용

---
- 인증 skip이 필요한 엔드포인트에 한해  jwt 필터에 적용되지 않도록 필터 로직을 수정하였습니다.
- 버그 고치다보니 로직이 지저분하고 결점이 있을 수 있을 것 같은데, 피드백 주실 점 있으시면 주시면 감사하겠습니다!
### 💡 참고 사항

---

### 🚨 현재 버그

---
- api/reissue 쪽에서 계속 401 에러가 발생하네요..별도로 로그도 찍히지 않고 무슨 문제인지 잘 모르겠습니다
### ☑️ Git Close

---