### PR TITLE
댓글 api content 속성을 추가하여 response 명시

### DIFF
--- a/src/main/java/ojosama/talkak/comment/controller/CommentApiController.java
+++ b/src/main/java/ojosama/talkak/comment/controller/CommentApiController.java
@@ -1,6 +1,8 @@
 package ojosama.talkak.comment.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -9,6 +11,7 @@ import ojosama.talkak.comment.dto.CommentRequest;
 import ojosama.talkak.comment.dto.CommentResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,9 +22,12 @@ public interface CommentApiController {
     @Operation(summary = "댓글 생성", description = "댓글을 생성합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "댓글 생성 성공"),
-        @ApiResponse(responseCode = "C001", description = "인증되지 않은 유저입니다."),
-        @ApiResponse(responseCode = "C002", description = "회원을 조회할 수 없습니다."),
-        @ApiResponse(responseCode = "C003", description = "존재하지 않는 videoId 입니다.")
+        @ApiResponse(responseCode = "C001", description = "인증되지 않은 유저입니다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "C002", description = "회원을 조회할 수 없습니다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "C003", description = "존재하지 않는 videoId 입니다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<CommentResponse> createComment(@PathVariable("videoId") Long videoId,
         @RequestBody CommentRequest commentRequest, Authentication authentication);
@@ -29,19 +35,26 @@ public interface CommentApiController {
     @Operation(summary = "댓글 조회", description = "영상의 모든 댓글을 조회합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "댓글 생성 성공"),
-        @ApiResponse(responseCode = "C001", description = "인증되지 않은 유저입니다."),
-        @ApiResponse(responseCode = "C002", description = "회원을 조회할 수 없습니다."),
-        @ApiResponse(responseCode = "C003", description = "존재하지 않는 videoId 입니다."),
-        @ApiResponse(responseCode = "C004", description = "존재하지 않는 commentId 입니다.")
+        @ApiResponse(responseCode = "C001", description = "인증되지 않은 유저입니다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "C002", description = "회원을 조회할 수 없습니다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "C003", description = "존재하지 않는 videoId 입니다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "C004", description = "존재하지 않는 commentId 입니다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<List<CommentResponse>> getCommentsByVideoId(@PathVariable Long videoId);
 
     @Operation(summary = "댓글 수정", description = "댓글을 수정합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "댓글 생성 성공"),
-        @ApiResponse(responseCode = "C001", description = "인증되지 않은 유저입니다."),
-        @ApiResponse(responseCode = "C002", description = "회원을 조회할 수 없습니다."),
-        @ApiResponse(responseCode = "C003", description = "존재하지 않는 videoId 입니다."),
+        @ApiResponse(responseCode = "C001", description = "인증되지 않은 유저입니다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "C002", description = "회원을 조회할 수 없습니다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "C003", description = "존재하지 않는 videoId 입니다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "C004", description = "존재하지 않는 commentId 입니다.")
     })
     ResponseEntity<String> updateComment(@PathVariable("commentId") Long commentId,
@@ -51,10 +64,14 @@ public interface CommentApiController {
     @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "댓글 생성 성공"),
-        @ApiResponse(responseCode = "C001", description = "인증되지 않은 유저입니다."),
-        @ApiResponse(responseCode = "C002", description = "회원을 조회할 수 없습니다."),
-        @ApiResponse(responseCode = "C003", description = "존재하지 않는 videoId 입니다."),
-        @ApiResponse(responseCode = "C004", description = "존재하지 않는 commentId 입니다.")
+        @ApiResponse(responseCode = "C001", description = "인증되지 않은 유저입니다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "C002", description = "회원을 조회할 수 없습니다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "C003", description = "존재하지 않는 videoId 입니다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "C004", description = "존재하지 않는 commentId 입니다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<String> deleteComment(@PathVariable("commentId") Long commentId,
         Authentication authentication);


### PR DESCRIPTION
### 🛠️ 작업 내용

댓글 관련 api 를 swagger 에서 확인하면 에러 발생 시 응답 형식이 이상하게 출력되는 문제가 있었습니다.
확인해보니 content 속성을 `ErrorResponse.class` 로 명시해주지 않아 이 부분 추가했습니다.

### 💡 참고 사항

---

### 🚨 현재 버그

---

### ☑️ Git Close

---