### PR TITLE
토큰 검사 로직 수정

### DIFF
--- a/src/main/java/ojosama/talkak/common/exception/code/AuthError.java
+++ b/src/main/java/ojosama/talkak/common/exception/code/AuthError.java
@@ -8,7 +8,8 @@ public enum AuthError implements ErrorCode {
 
     /* 401 Unauthorized */
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 access token입니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 refresh token입니다.");
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 refresh token입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "만료된 토큰입니다.");
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
### 🛠️ 작업 내용

요청으로 받은 토큰이 리프레시 토큰인지를 검사하는 과정에서, 만료된 경우를 고려하지 않아 에러가 발생하던 기존의 로직을 다음과 같이 수정하였습니다.

- 만료된 토큰으로 요청한 경우
  - `INVALID_TOKEN` 에러 코드를 추가하여 액세스 토큰, 리프레시 토큰 구분 없이 해당 에러를 반환
- 유효한 토큰으로 요청한 경우
  - 리프레시 토큰일 경우
    - 아래 로직을 수행하지 않고 넘어감
  - 액세스 토큰일 경우
    - 정상적으로 로직을 수행함

---

### 💡 참고 사항

---

### 🚨 현재 버그

---

### ☑️ Git Close

---