### PR TITLE
Reaction API 잘못된 예외 처리 로직 수정

### DIFF
--- a/src/main/java/ojosama/talkak/auth/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/ojosama/talkak/auth/filter/JwtAuthorizationFilter.java
@@ -42,7 +42,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         FilterChain filterChain) throws ServletException, IOException
     {
         String headerValue = request.getHeader(HttpHeaders.AUTHORIZATION);
-        System.out.println("headerValue = " + headerValue);
         if (headerValue == null) {
             filterChain.doFilter(request, response);
             return;

--- a/src/main/java/ojosama/talkak/comment/controller/CommentController.java
+++ b/src/main/java/ojosama/talkak/comment/controller/CommentController.java
@@ -30,7 +30,7 @@ public class CommentController implements CommentApiController {
         @PathVariable("videoId") Long videoId, @RequestBody CommentRequest commentRequest,
         Authentication authentication) {
         Long memberId = Long.valueOf(authentication.getPrincipal().toString());
-        return ResponseEntity.ok(commentService.createComment(videoId, memberId, commentRequest));
+        return ResponseEntity.ok(commentService.createComment(memberId, videoId, commentRequest));
     }
 
     @GetMapping

--- a/src/main/java/ojosama/talkak/reaction/controller/ReactionController.java
+++ b/src/main/java/ojosama/talkak/reaction/controller/ReactionController.java
@@ -22,8 +22,8 @@ public class ReactionController implements ReactionApiController {
     @PostMapping("/like")
     public ResponseEntity<Void> toggleLike(
         @PathVariable Long videoId, Authentication authentication) {
-        Long id = Long.valueOf(authentication.getPrincipal().toString());
-        reactionService.toggleLike(videoId, id);
+        Long memberId = Long.valueOf(authentication.getPrincipal().toString());
+        reactionService.toggleLike(memberId, videoId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/ojosama/talkak/reaction/service/ReactionService.java
+++ b/src/main/java/ojosama/talkak/reaction/service/ReactionService.java
@@ -4,11 +4,15 @@ import ojosama.talkak.common.exception.TalKakException;
 import ojosama.talkak.common.exception.code.ReactionError;
 import ojosama.talkak.common.util.HashConverter;
 import ojosama.talkak.common.util.RedisUtil;
+import ojosama.talkak.member.domain.Member;
+import ojosama.talkak.member.repository.MemberRepository;
 import ojosama.talkak.recommendation.domain.Reaction;
 import ojosama.talkak.recommendation.domain.VideoInfo;
 import ojosama.talkak.recommendation.innerkey.VideoHashKey;
 import ojosama.talkak.recommendation.key.VideoKey;
 import ojosama.talkak.recommendation.repository.ReactionsRepository;
+import ojosama.talkak.video.domain.Video;
+import ojosama.talkak.video.repository.VideoRepository;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,7 +22,8 @@ public class ReactionService {
     private final ReactionsRepository reactionsRepository;
     private final RedisUtil redisUtil;
     private final HashConverter hashConverter;
-
+    private final MemberRepository memberRepository;
+    private final VideoRepository videoRepository;
 
     // 영상을 시청함과 동시에 Reactions 생성
     public Reaction createReaction(Long memberId, Long videoId) {
@@ -26,14 +31,18 @@ public class ReactionService {
     }
 
     public void toggleLike(Long memberId, Long videoId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> TalKakException.of(ReactionError.INVALID_MEMBER_ID));
+        Video video = videoRepository.findById(videoId)
+                .orElseThrow(() -> TalKakException.of(ReactionError.INVALID_VIDEO_ID));
+
         reactionsRepository.findByMemberIdAndVideoId(memberId, videoId)
             .ifPresentOrElse(reaction -> {
                     reaction.updateLike();
-                    reactionsRepository.save(memberId, videoId, reaction);
+                    reactionsRepository.save(member.getId(), video.getId(), reaction);
                 }, ()
                     -> {
-                    createReaction(memberId, videoId);
-                    throw TalKakException.of(ReactionError.FAILED_PROCESS_REQUEST);
+                    createReaction(member.getId(), video.getId());
                 }
             );
     }


### PR DESCRIPTION
### 🛠️ 작업 내용

---
- Reaction 좋아요 요청 API에서 정상 로직에 대해 예외를 반환하는 오류를 해결하였습니다.
- Reaction/Comment API에서 서비스 로직으로 넘기는 파라미터의 순서가 잘못된 부분을 수정하였습니다.
### 💡 참고 사항

---

### 🚨 현재 버그

---

### ☑️ Git Close

---