### PR TITLE
/error 인가 허용 추가

### DIFF
--- a/src/main/java/ojosama/talkak/auth/config/SecurityConfig.java
+++ b/src/main/java/ojosama/talkak/auth/config/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
                     .requestMatchers(authProperties.authorizationUri()).permitAll()
                     .requestMatchers("/api/reissue").permitAll()
                     .requestMatchers("/api/issue").permitAll()
-                    .requestMatchers("/api/videos", "/api/videos/{videoId:\\d+}", "/api/videos/youtube/**").permitAll()
+                    .requestMatchers("/api/videos", "/api/videos/{videoId:\\d+}", "/api/videos/youtube/**", "/error").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/videos/{videoId:\\d+}/comments").permitAll()
                     .anyRequest().authenticated()
             )

--- a/src/main/java/ojosama/talkak/auth/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/ojosama/talkak/auth/filter/JwtAuthorizationFilter.java
@@ -81,7 +81,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
-        AuthError error = AuthError.INVALID_TOKEN;
+        AuthError error = AuthError.EXPIRED_TOKEN;
         response.getWriter()
             .write(objectMapper.writeValueAsString(
                 ErrorResponse.of(error.status(), error.code(), error.message())));

--- a/src/main/java/ojosama/talkak/common/exception/code/AuthError.java
+++ b/src/main/java/ojosama/talkak/common/exception/code/AuthError.java
@@ -1,5 +1,7 @@
 package ojosama.talkak.common.exception.code;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
@@ -9,7 +11,8 @@ public enum AuthError implements ErrorCode {
     /* 401 Unauthorized */
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 access token입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 refresh token입니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "만료된 토큰입니다.");
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "만료된 토큰입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "토큰을 올바르게 입력해주세요.");
 
     private final HttpStatus status;
     private final String code;
@@ -28,5 +31,16 @@ public enum AuthError implements ErrorCode {
     @Override
     public String message() {
         return message;
+    }
+
+    public static AuthError from(Exception exception) {
+        return Optional.ofNullable(exception)
+            .map(e -> {
+                if (e instanceof ExpiredJwtException) {
+                    return EXPIRED_TOKEN;
+                }
+                return INVALID_TOKEN;
+            })
+            .orElse(INVALID_TOKEN);
     }
 }


### PR DESCRIPTION
### 🛠️ 작업 내용

---
- 기본적으로 스프링에서 예외가 발생할때 /error 엔드포인트로 내부 포워딩시킵니다.
- /error에 대한 인가 허용이 되어있지 않아서 /error 엔드포인트로 출력되는 예외들을 정확한 path로 예외를 출력하도록 /error 엔드포인트에 대한 permitAll을 추가하였습니다.
### 💡 참고 사항

---

### 🚨 현재 버그

---

### ☑️ Git Close

---