### PR TITLE
카테고리 타입 생성 순서 변경

### DIFF
--- a/src/main/java/ojosama/talkak/category/domain/CategoryType.java
+++ b/src/main/java/ojosama/talkak/category/domain/CategoryType.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum CategoryType {
-    MUSIC("음악"), JOURNEY("여행"), GAME("게임"), SPORT("스포츠"), FOOD("음식");
+    FOOD("음식"), JOURNEY("여행"), GAME("게임"), MUSIC("음악"), SPORT("스포츠");
 
     private final String name;
 


### PR DESCRIPTION
### 🛠️ 작업 내용

---
FOOD("음식"), JOURNEY("여행"), GAME("게임"), MUSIC("음악"), SPORT("스포츠");
-해당 순서로 카테고리 타입이 생성되도록 순서를 변경하였습니다.
### 💡 참고 사항

---

### 🚨 현재 버그

---

### ☑️ Git Close

---